### PR TITLE
Support es6 files as javascript

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -3,6 +3,7 @@
   'js'
   'htc'
   'jsx'
+  'es6'
 ]
 'firstLineMatch': '^#!.*\\bnode'
 'keyEquivalent': '^~J'


### PR DESCRIPTION
The `ember-appkit-rails` library uses the `.es6` extension to support ES6 modules. Adds support for this type.
