### PR TITLE
Fix code style of Object Method snippet.

### DIFF
--- a/snippets/language-javascript.cson
+++ b/snippets/language-javascript.cson
@@ -1,7 +1,7 @@
 '.source.js':
   'Object Method':
     'prefix': ':f'
-    'body': '${1:method_name}: function (${2:attribute}){\n\t$3\n}${4:,}'
+    'body': '${1:method_name}: function (${2:attribute}) {\n\t$3\n}${4:,}'
   'Object key — key: "value"':
     'prefix': ':'
     'body': '${1:key}: ${2:"${3:value}"}${4:, }'


### PR DESCRIPTION
Add an extra space to make the code style of the Object Method snippet consistent with common practice.

Previous example output:

```
method_name: function (attribute){

},
```

Output with this change:

```
method_name: function (attribute) {

},
```
