### PR TITLE
Remove irrelevant keywords for grammar

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -286,15 +286,15 @@
     'name': 'comment.block.html.js'
   }
   {
-    'match': '(?<!\\.)\\b(boolean|byte|char|class|double|enum|float|function|int|interface|long|short|void)\\b'
+    'match': '(?<!\\.)\\b(class|enum|function|interface|void)\\b'
     'name': 'storage.type.js'
   }
   {
-    'match': '(?<!\\.)\\b(const|export|extends|final|implements|native|private|protected|public|static|synchronized|throws|transient|var|volatile)\\b'
+    'match': '(?<!\\.)\\b(const|export|extends|implements|let|private|protected|public|static|var)\\b'
     'name': 'storage.modifier.js'
   }
   {
-    'match': '(?<!\\.)\\b(break|case|catch|continue|default|do|else|finally|for|goto|if|import|package|return|switch|throw|try|while)\\b'
+    'match': '(?<!\\.)\\b(break|case|catch|continue|default|do|else|finally|for|if|import|package|return|switch|throw|try|while|yield)\\b'
     'name': 'keyword.control.js'
   }
   {


### PR DESCRIPTION
The items removed from the keyword list have never actually been Keywords in JavaScript. In ES3, they were specified as either ReservedWords or FutureReservedWords, but were removed in ES5 and therefore will never actually be a thing in the language.

It will be nice to finally use the word "byte" as an identifier without having unnecessary syntax highlighting applied. 

Signed-off-by: Rick Waldron waldron.rick@gmail.com
