### PR TITLE
Exponential Notations should also be parsed as Numbers

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -206,7 +206,7 @@
     'name': 'support.function.js.firebug'
   }
   {
-    'match': '\\b((0(x|X)[0-9a-fA-F]+)|([0-9]+(\\.[0-9]+)?)+((e|E)[+-]?[0-9]+)?)\\b'
+    'match': '\\b((0(x|X)[0-9a-fA-F]+)|([0-9]+(\\.[0-9]+)?)((e|E)[+-]?[0-9]+)?)\\b'
     'name': 'constant.numeric.js'
   }
   {


### PR DESCRIPTION
#### Issue

The grammar/syntax for JavaScript does not highlight the coefficient and the character `e` in the scientific notation.
#### Fix

``` patch
-    'match': '\\b((0(x|X)[0-9a-fA-F]+)|([0-9]+(\\.[0-9]+)?))\\b'
+    'match': '\\b((0(x|X)[0-9a-fA-F]+)|([0-9]+(\\.[0-9]+)?)((e|E)[+-]?[0-9]+)?)\\b'
```
#### Tests

Here are some of the matching results from the modified regex - http://regex101.com/r/kI0fC9
#### Screenshots

Here is how it looks now:
![image](https://f.cloud.github.com/assets/171072/2418434/a415ec36-ab42-11e3-9e20-e046d915a0a4.png)

And this is how it will look after this fix is applied:
![image](https://f.cloud.github.com/assets/171072/2418440/bc3df3e4-ab42-11e3-8e21-4d4cc04283bc.png)
