### PR TITLE
Move IIFE snippet to before if/else snippet.

### DIFF
--- a/snippets/language-javascript.cson
+++ b/snippets/language-javascript.cson
@@ -38,15 +38,15 @@
   'getElementsByTagName':
     'prefix': 'get'
     'body': 'getElementsByTagName(${1:\'${2:tagName}\'})'
+  'Immediately-Invoked Function Expression':
+    'prefix': 'iife'
+    'body': '(function() {\n${1:\t"use strict";\n}\t$2\n}());'
   'if … else':
     'prefix': 'ife'
     'body': 'if (${1:true}) {\n\t$2\n} else {\n\t$3\n}'
   'if':
     'prefix': 'if'
     'body': 'if (${1:true}) {\n\t$2\n}'
-  'Immediately-Invoked Function Expression':
-    'prefix': 'iife'
-    'body': '(function() {\n${1:\t"use strict";\n}\t$2\n}());'
   'log':
     'prefix': 'log'
     'body': 'console.log($1);$0'


### PR DESCRIPTION
If you type `iife<tab>`, the `ife` snippet takes precedence because it is first in the file. So instead of the expected IIFE, you get:

``` js
iif (true) {

} else {

}
```
