### PR TITLE
Remove .jsx extension

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -2,7 +2,6 @@
 'fileTypes': [
   'js'
   'htc'
-  'jsx'
   '_js'
   'es6'
 ]


### PR DESCRIPTION
I can only assume this was added as some sort of stopgap JSX support, but now the `react` package exists (https://github.com/orktes/atom-react) and highlights better than the plain JS grammar, so it makes sense to remove .jsx from the extensions here.
