### PR TITLE
Fix indentation for single line if/else/while/for

### DIFF
--- a/scoped-properties/language-javascript.cson
+++ b/scoped-properties/language-javascript.cson
@@ -10,6 +10,7 @@
       | ^ \\s* if \\s* \\( (?!.*?\\belse\\b)
       | ^ \\s* \\}? \\s* else \\s*
       | ^ \\s* (for|while) \\s* \\(
+      | ^ \\s* do \\s* $
       '
     'decreaseIndentPattern': '(?x)
         ^(.*\\*/)?\\s*(\\}|\\)|case|default)


### PR DESCRIPTION
While doing atom/language-c#27 I noticed these were also broken in the JS grammar.

This fixes indent/outdent for `if/else/while/for` statements that do not have curlies.
