### PR TITLE
Don't de-indent case and default statements

### DIFF
--- a/scoped-properties/language-javascript.cson
+++ b/scoped-properties/language-javascript.cson
@@ -13,6 +13,6 @@
       | ^ \\s* do \\s* $
       '
     'decreaseIndentPattern': '(?x)
-        ^(.*\\*/)?\\s*(\\}|\\)|case|default)
+        ^(.*\\*/)?\\s*(\\}|\\))
       | ^\\s* else \\s*$
       '


### PR DESCRIPTION
This commit changes the formatting of a `switch` statement from

```
switch(x) {
case 1:
    //stuff
case 2:
    //stuff
default:
    //stuff
}
```

to

```
switch(x) {
    case 1:
        //stuff
    case 2:
        //stuff
    default:
        //stuff
}
```

Note the indentation is not decreased for `case` and `default` statements.

I know others will likely disagree with this style preference but I couldn't figure out how to control this at runtime in my init script or keymap file.

Is there a way to add this change at runtime or add a preference so I wouldn't have to maintain a fork and keep it up to date with upstream changes?
