### PR TITLE
Add "start docblock" snippet

### DIFF
--- a/snippets/language-javascript.cson
+++ b/snippets/language-javascript.cson
@@ -71,3 +71,6 @@
   'while':
     'prefix': 'while'
     'body': 'while (${1:true}) {\n\t$2\n}'
+  'Start Docblock':
+    'prefix': '/**'
+    'body': '/**\n * $0\n */'


### PR DESCRIPTION
This allows the ability to type `/** <tab>`and then it will expand to the full docblock.
