### PR TITLE
Update function-params patterns to match TextMate's

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -425,15 +425,12 @@
   'function-params':
     'patterns': [
       {
-        'begin': '(?![\\s,)])'
+        'begin': '(?=[\\p{L}\\p{Nl}$_])'
         'end': '(?=[,)])'
         'patterns': [
           {
-            'match': '\\G[$_a-zA-Z][$_a-zA-Z0-9]*'
+            'match': '\\G[\\p{L}\\p{Nl}$_][\\p{L}\\p{Nl}$\\p{Mn}\\p{Mc}\\p{Nd}\\p{Pc}\\x{200C}\\x{200D}]*'
             'name': 'variable.parameter.function.js'
-          }
-          {
-            'include': '$self'
           }
         ]
       }


### PR DESCRIPTION
Fixes https://github.com/atom/language-javascript/issues/24. 

This updates the (outdated) patterns for `function-params` to match [the current TextMate patterns](https://github.com/textmate/javascript.tmbundle/blob/3c5f53fbdfeff2ce817551eafd6c61a9377488b5/Syntaxes/JavaScript.plist#L584-L606).

Screenshot (notice that all parameters are correctly recognized, regardless of the position of the separating comma):

![screen shot 2014-06-28 at 1 14 37 pm](https://cloud.githubusercontent.com/assets/38924/3420627/7063a6c8-feb5-11e3-8db5-87c2df511d86.png)

It seems that the grammars for language-javascript were generated some time ago from the [TextMate bundle](https://github.com/textmate/javascript.tmbundle), and there's been a number of changes/fixes to that bundle in the meantime. I wouldn't be surprised if some of the [other reported issues](https://github.com/atom/language-javascript/issues) would be fixed by updating all langauge-javascript patterns with the ones in TextMate's bundle.

I tried generating a new package from the current version of TextMate's JavaScript bundle, and the diff for the grammar is pretty big. :smile: 

It seems to me that it's worth thinking about getting updates from TextMate's bundles in a systematic way across all our language-\* packages, and perhaps even contributing changes back upstream. In the meantime, I'm happy to whack-a-mole some of these issues. :bug: :hammer: :bug: :hammer: :bug: :hammer: 

cc @kevinsawicki @nathansobo @probablycorey 
