### PR TITLE
Treat with as a control keyword

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -304,11 +304,11 @@
     'name': 'storage.modifier.js'
   }
   {
-    'match': '(?<!\\.)\\b(break|case|catch|continue|default|do|else|finally|for|if|import|package|return|switch|throw|try|while|yield)(?!\\s*:)\\b'
+    'match': '(?<!\\.)\\b(break|case|catch|continue|default|do|else|finally|for|if|import|package|return|switch|throw|try|while|yield|with)(?!\\s*:)\\b'
     'name': 'keyword.control.js'
   }
   {
-    'match': '(?<!\\.)\\b(delete|in|instanceof|new|typeof|with|void)(?!\\s*:)\\b'
+    'match': '(?<!\\.)\\b(delete|in|instanceof|new|typeof|void)(?!\\s*:)\\b'
     'name': 'keyword.operator.js'
   }
   {

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -26,6 +26,11 @@ describe "Javascript grammar", ->
         expect(tokens[1].scopes).toEqual ["source.js", scope]
         expect(tokens[2].value).toEqual delim
         expect(tokens[2].scopes).toEqual ["source.js", scope, "punctuation.definition.string.end.js"]
+        
+  describe "keywords", ->
+    it "tokenizes with as a keyword", ->
+      {tokens} = grammar.tokenizeLine('with')
+      expect(tokens[0]).toEqual value: 'with', scopes: ['source.js', 'keyword.control.js']
 
   describe "regular expressions", ->
     it "tokenizes regular expressions", ->


### PR DESCRIPTION
Since `with` begins a block, it seems more sensible to categorize it with `for` and `if` than with `typeof`.
