### PR TITLE
Adding node globals to grammar

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -420,6 +420,14 @@
     'match': '\\A#!.*$'
     'name': 'comment.line.shebang.js'
   }
+  {
+    'match': '(?<!\\.)\\b(require)(?!\\s*:)\\b'
+    'name': 'support.function.js'
+  }
+  {
+    'match': '(?<!\\.)\\b(module|exports|__filename|__dirname|global|process)(?!\\s*:)\\b'
+    'name': 'support.variable.js'
+  }
 ]
 'repository':
   'function-params':


### PR DESCRIPTION
This addresses issue #45 by adding 2 new grammar rules:
- `require` = `support.function.js`
- `module`, `exports`, `__filename`, `__dirname`, `global`, `process` = `support.variable.js`

I'm willing to drop `global` and `process`, since that wasn't mentioned explicitly in the ticket. Of course I'll make any other changes requested to merge this in.
