### PR TITLE
Add support for new ES6 numeric literals

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -216,7 +216,7 @@
     'name': 'support.function.js.firebug'
   }
   {
-    'match': '\\b((0(x|X)[0-9a-fA-F]+)|([0-9]+(\\.[0-9]+)?)((e|E)[+-]?[0-9]+)?)\\b'
+    'match': '\\b((0(x|X)[0-9a-fA-F]+)|(0(b|B)[01]+)|(0(o|O)[0-7]+)|([0-9]+(\\.[0-9]+)?)((e|E)[+-]?[0-9]+)?)\\b'
     'name': 'constant.numeric.js'
   }
   {

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -65,6 +65,24 @@ describe "Javascript grammar", ->
       expect(tokens[6]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.end.js']
       expect(tokens[7]).toEqual value: ']', scopes: ['source.js', 'meta.brace.square.js']
 
+      {tokens} = grammar.tokenizeLine('0x1D306')
+      expect(tokens[0]).toEqual value: '0x1D306', scopes: ['source.js', 'constant.numeric.js']
+
+      {tokens} = grammar.tokenizeLine('0X1D306')
+      expect(tokens[0]).toEqual value: '0X1D306', scopes: ['source.js', 'constant.numeric.js']
+
+      {tokens} = grammar.tokenizeLine('0b011101110111010001100110')
+      expect(tokens[0]).toEqual value: '0b011101110111010001100110', scopes: ['source.js', 'constant.numeric.js']
+
+      {tokens} = grammar.tokenizeLine('0B011101110111010001100110')
+      expect(tokens[0]).toEqual value: '0B011101110111010001100110', scopes: ['source.js', 'constant.numeric.js']
+
+      {tokens} = grammar.tokenizeLine('0o1411')
+      expect(tokens[0]).toEqual value: '0o1411', scopes: ['source.js', 'constant.numeric.js']
+
+      {tokens} = grammar.tokenizeLine('0O1411')
+      expect(tokens[0]).toEqual value: '0O1411', scopes: ['source.js', 'constant.numeric.js']
+
   describe "operators", ->
     it "tokenizes void correctly", ->
       {tokens} = grammar.tokenizeLine('void')


### PR DESCRIPTION
https://people.mozilla.org/~jorendorff/es6-draft.html#sec-literals-numeric-literals

```
BinaryIntegerLiteral ::
  0b BinaryDigits
  0B BinaryDigits

BinaryDigits ::
  BinaryDigit
  BinaryDigits BinaryDigit

BinaryDigit :: one of
  0 1

OctalIntegerLiteral ::
  0o OctalDigits
  0O OctalDigits

OctalDigits ::
  OctalDigit
  OctalDigits OctalDigit

OctalDigit :: one of
  0 1 2 3 4 5 6 7
```
