### PR TITLE
snippet: iife, \t removed from first selection

### DIFF
--- a/snippets/language-javascript.cson
+++ b/snippets/language-javascript.cson
@@ -40,7 +40,7 @@
     'body': 'getElementsByTagName(${1:\'${2:tagName}\'})'
   'Immediately-Invoked Function Expression':
     'prefix': 'iife'
-    'body': '(function() {\n${1:\t"use strict";\n}\t$2\n}());'
+    'body': '(function() {\n\t${1:"use strict";\n}\t$2\n}());'
   'if … else':
     'prefix': 'ife'
     'body': 'if (${1:true}) {\n\t$2\n} else {\n\t$3\n}'


### PR DESCRIPTION
because if we decide to delete first selection then cursor indentation is preserved.

Cursor position after deleting first selection $1
X - Cursor position

before:

```
(function() {
X
}());
```

after:

```
(function() {
  X
}());
```

gif
<img src="http://i.imgur.com/gyVX9wo.gif">
