### PR TITLE
snippets: changed selection behaviour of for cycle

### DIFF
--- a/snippets/language-javascript.cson
+++ b/snippets/language-javascript.cson
@@ -16,7 +16,7 @@
     'body': 'else {\n\t$1\n}'
   'for':
     'prefix' : 'for'
-    'body' : 'for (var ${2:i} = 0; ${2:i} < ${1:array}.length; ${2:i}++) {\n\t${1:array}[${2:i}]\n}'
+    'body' : 'for (var ${2:i} = 0; ${2:i} < ${1:array}.length; ${2:i}++) {\n\t${1:array}[${2:i}]$3\n}'
   'for in':
     'prefix': 'forin'
     'body': 'for (${1:variable} in ${2:object}) {\n\t${5:if (${3:object}.hasOwnProperty(${4:variable})) {\n\t\t$6\n\t}}\n}'


### PR DESCRIPTION
first selection - all `array` variables, second selection all `i` variables
(previous behavior: first selection - first `array` var, second selection - second `array` var).

I have ran into some errors when i was tabbing from 1st selection to 2nd selection but it was already reported issue (https://github.com/emmetio/emmet-atom/issues/171) related to 3rd party plugin (Emmet). Works fine with Emmet turned off.

gif
<img src="http://i.imgur.com/APyL04G.gif">
