### PR TITLE
Autoindent rules for arrays

### DIFF
--- a/settings/language-javascript.cson
+++ b/settings/language-javascript.cson
@@ -4,10 +4,11 @@
     'foldEndPattern': '^\\s*\\}|^\\s*\\]|^\\s*\\)'
     'increaseIndentPattern': '(?x)
         \\{ [^}"\']* $
+      | \\[ [^\\]"\']* $
       | \\( [^)"\']* $
       | case[\\s\\S]*: $
       | default: $
       '
     'decreaseIndentPattern': '(?x)
-        ^ \\s* (\\s* /[*] .* [*]/ \\s*)* [})]
+        ^ \\s* (\\s* /[*] .* [*]/ \\s*)* [}\\])]
       '


### PR DESCRIPTION
As a follow-up to #77, where @jbt commented:

>  I'd contend that the ]) shouldn't be automatically indented

This adds autoindent rules for arrays, like:

```js
var pets = [
  'kitten',
  'fish'
];
```

If not auto-indenting arrays was a conscious decision, please feel free to close!