### PR TITLE
Match iojs shebangs

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -5,7 +5,7 @@
   '_js'
   'es6'
 ]
-'firstLineMatch': '^#!.*\\bnode'
+'firstLineMatch': '^#!.*\\b(node|iojs)'
 'name': 'JavaScript'
 'patterns': [
   {


### PR DESCRIPTION
Add support for files with a shebang like `#!/usr/bin/env iojs`

Fixes #100 