### PR TITLE
added `from` to the regex matching `keyword.control.js`

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -312,7 +312,7 @@
     'name': 'storage.modifier.js'
   }
   {
-    'match': '(?<!\\.)\\b(break|case|catch|continue|do|else|finally|for|if|import|package|return|switch|throw|try|while|with|yield)(?!\\s*:)\\b'
+    'match': '(?<!\\.)\\b(break|case|catch|continue|do|else|finally|for|if|import|from|package|return|switch|throw|try|while|with|yield)(?!\\s*:)\\b'
     'name': 'keyword.control.js'
   }
   {


### PR DESCRIPTION
added the `from` keyword, used in ES6 import statements.
```js
import foo from './bar.js';
```