### PR TITLE
:apple: match on shebangs of JS-syntax AppleScripts

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -6,7 +6,7 @@
   'es6'
   'pjs'
 ]
-'firstLineMatch': '^#!.*\\b(node|iojs)'
+'firstLineMatch': '^#!.*\\b(node|iojs|JavaScript)'
 'name': 'JavaScript'
 'patterns': [
   {


### PR DESCRIPTION
On OSX Yosemite 10.10, AppleScripts can be written in JavaScript language and are interpreted using JavaScriptCore + a Cocoa bridge.

Such scripts can be launched via a [shebang](https://github.com/dtinth/JXA-Cookbook/wiki/Using-JavaScript-for-Automation#creating-a-shebang-script) in the first line and stashed in ~/bin.

This commit makes these JS-format AppleScripts read out as JS code in atom.
```
>>> '#!/usr/bin/osascript -l JavaScript'.match('^#!.*\\b(node|iojs|JavaScript)')
#!/usr/bin/osascript -l JavaScript,JavaScript
```
