### PR TITLE
Unified quotes in snippets

### DIFF
--- a/snippets/language-javascript.cson
+++ b/snippets/language-javascript.cson
@@ -4,7 +4,7 @@
     'body': '${1:method_name}: function (${2:attribute}) {\n\t$3\n}${4:,}'
   'Object key — key: "value"':
     'prefix': ':'
-    'body': '${1:key}: ${2:"${3:value}"}${4:, }'
+    'body': '${1:key}: ${2:\'${3:value}\'}${4:, }'
   'Prototype':
     'prefix': 'proto'
     'body': '${1:class_name}.prototype.${2:method_name} = function (${3:first_argument}) {\n\t${0:// body...}\n};'
@@ -55,7 +55,7 @@
     'body': 'querySelectorAll(${1:\'${2:query}\'})'
   'Immediately-Invoked Function Expression':
     'prefix': 'iife'
-    'body': '(function() {\n\t${1:"use strict";\n}\t$2\n}());'
+    'body': '(function() {\n\t${1:\'use strict\';\n}\t$2\n}());'
   'if … else':
     'prefix': 'ife'
     'body': 'if (${1:true}) {\n\t$2\n} else {\n\t$3\n}'


### PR DESCRIPTION
Reason: majority of snippets use single quotes in them.

Also it should probably be configurable which type of quotes will be used (not sure if there is some ticket for that).