### PR TITLE
Removed useless statement variables from try snippet

### DIFF
--- a/snippets/language-javascript.cson
+++ b/snippets/language-javascript.cson
@@ -88,7 +88,7 @@
     'body': 'switch (${1:expression}) {\n\tcase ${2:expression}:\n\t\t$4\n\t\tbreak;$5\n\tdefault:\n\t\t$3\n}'
   'try':
     'prefix': 'try'
-    'body': 'try {\n\t$1\n} catch (${2:variable}) {\n\t$3\n}${4: finally {\n\t$5\n}}'
+    'body': 'try {\n\t$1\n} catch (${2:e}) {\n\t$3\n}${4: finally {\n\t$5\n}}'
   'while':
     'prefix': 'while'
     'body': 'while (${1:true}) {\n\t$2\n}'

--- a/snippets/language-javascript.cson
+++ b/snippets/language-javascript.cson
@@ -88,7 +88,7 @@
     'body': 'switch (${1:expression}) {\n\tcase ${2:expression}:\n\t\t$4\n\t\tbreak;$5\n\tdefault:\n\t\t$3\n}'
   'try':
     'prefix': 'try'
-    'body': 'try {\n\t${1:statements}\n} catch (${2:variable}) {\n\t${3:statements}\n}${4: finally {\n\t${5:statements}\n}}'
+    'body': 'try {\n\t$1\n} catch (${2:variable}) {\n\t$3\n}${4: finally {\n\t$5\n}}'
   'while':
     'prefix': 'while'
     'body': 'while (${1:true}) {\n\t$2\n}'


### PR DESCRIPTION
And renamed parameter in try catch snippet from variable to e

Preview (old behavior at the top, new at the bottom)
![try2](https://cloud.githubusercontent.com/assets/6587821/6883296/8950c778-d5a7-11e4-864c-ca422ab7e341.gif)
