### PR TITLE
:bug: Fix tokenization for anonymous functions

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -65,7 +65,7 @@
     'name': 'meta.function.js'
   }
   {
-    'begin': '([a-zA-Z_?.$][\\w?.$]*)\\.([a-zA-Z_?.$][\\w?.$]*)\\s*(=)\\s*(function\\*?)\\s*(\\*?)(\\()'
+    'begin': '([a-zA-Z_?.$][\\w?.$]*)\\.([a-zA-Z_?.$][\\w?.$]*)\\s*(=)\\s*(function\\*?)\\s*(\\*?)\\s*([a-zA-Z_?$][\\w?$]*)?\\s*(\\()' #
     'beginCaptures':
       '1':
         'name': 'support.class.js'
@@ -78,6 +78,8 @@
       '5':
         'name': 'storage.type.function.js'
       '6':
+        'name': 'entity.name.function.js'
+      '7':
         'name': 'punctuation.definition.parameters.begin.js'
     'comment': 'match stuff like: Sound.play = function() { … }'
     'end': '(\\))'
@@ -92,7 +94,7 @@
     ]
   }
   {
-    'begin': '([a-zA-Z_?$][\\w?$]*)\\s*(=)\\s*(function\\*?)\\s*(\\*?)(\\()'
+    'begin': '([a-zA-Z_?$][\\w?$]*)\\s*(=)\\s*(function\\*?)\\s*(\\*?)\\s*([a-zA-Z_?$][\\w?$]*)?\\s*(\\()'
     'beginCaptures':
       '1':
         'name': 'entity.name.function.js'
@@ -103,6 +105,8 @@
       '4':
         'name': 'storage.type.function.js'
       '5':
+        'name': 'entity.name.function.js'
+      '6':
         'name': 'punctuation.definition.parameters.begin.js'
     'comment': 'match stuff like: play = function() { … }'
     'end': '(\\))'
@@ -140,7 +144,7 @@
     ]
   }
   {
-    'begin': '\\b([a-zA-Z_?.$][\\w?.$]*)\\s*:\\s*\\b(function\\*?)?\\s*(\\*?)(\\()'
+    'begin': '\\b([a-zA-Z_?.$][\\w?.$]*)\\s*:\\s*\\b(function\\*?)?\\s*(\\*?)\\s*([a-zA-Z_?$][\\w?$]*)?\\s*(\\()'
     'beginCaptures':
       '1':
         'name': 'entity.name.function.js'
@@ -149,6 +153,8 @@
       '3':
         'name': 'storage.type.function.js'
       '4':
+        'name': 'entity.name.function.js'
+      '5':
         'name': 'punctuation.definition.parameters.begin.js'
     'comment': 'match stuff like: foobar: function() { … }'
     'end': '(\\))'
@@ -163,7 +169,7 @@
     ]
   }
   {
-    'begin': '(?:((\')(.*?)(\'))|((")(.*?)(")))\\s*:\\s*\\b(function\\*?)?\\s*(\\*?)(\\()'
+    'begin': '(?:((\')(.*?)(\'))|((")(.*?)(")))\\s*:\\s*\\b(function\\*?)?\\s*(\\*?)\\s*([a-zA-Z_?$][\\w?$]*)?\\s*(\\()'
     'beginCaptures':
       '1':
         'name': 'string.quoted.single.js'
@@ -186,6 +192,8 @@
       '10':
         'name': 'storage.type.function.js'
       '11':
+        'name': 'entity.name.function.js'
+      '12':
         'name': 'punctuation.definition.parameters.begin.js'
     'comment': 'Attempt to match "foo": function'
     'end': '(\\))'

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -124,6 +124,43 @@ describe "Javascript grammar", ->
     expect(tokens[7]).toEqual value: '*/', scopes: ['source.js', 'meta.function.json.js', 'comment.block.documentation.js', 'punctuation.definition.comment.js']
     expect(tokens[8]).toEqual value: 'bar', scopes: ['source.js', 'meta.function.json.js', 'variable.parameter.function.js']
 
+  describe "non-anonymous functions", ->
+    it "tokenizes methods", ->
+      {tokens} = grammar.tokenizeLine('Foo.method = function nonAnonymous(')
+
+      expect(tokens[0]).toEqual value: 'Foo', scopes: ['source.js', 'meta.function.js', 'support.class.js']
+      expect(tokens[2]).toEqual value: 'method', scopes: ['source.js', 'meta.function.js', 'entity.name.function.js']
+      expect(tokens[4]).toEqual value: '=', scopes: ['source.js', 'meta.function.js', 'keyword.operator.js']
+      expect(tokens[6]).toEqual value: 'function', scopes: ['source.js', 'meta.function.js', 'storage.type.function.js']
+      expect(tokens[8]).toEqual value: 'nonAnonymous', scopes: ['source.js', 'meta.function.js', 'entity.name.function.js']
+      expect(tokens[9]).toEqual value: '(', scopes: ['source.js', 'meta.function.js', 'punctuation.definition.parameters.begin.js']
+
+    it "tokenizes functions", ->
+      {tokens} = grammar.tokenizeLine('var func = function nonAnonymous(')
+
+      expect(tokens[0]).toEqual value: 'var', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[2]).toEqual value: 'func', scopes: ['source.js', 'meta.function.js', 'entity.name.function.js']
+      expect(tokens[4]).toEqual value: '=', scopes: ['source.js', 'meta.function.js', 'keyword.operator.js']
+      expect(tokens[6]).toEqual value: 'function', scopes: ['source.js', 'meta.function.js', 'storage.type.function.js']
+      expect(tokens[8]).toEqual value: 'nonAnonymous', scopes: ['source.js', 'meta.function.js', 'entity.name.function.js']
+      expect(tokens[9]).toEqual value: '(', scopes: ['source.js', 'meta.function.js', 'punctuation.definition.parameters.begin.js']
+
+    it "tokenizes object functions", ->
+      {tokens} = grammar.tokenizeLine('foo: function nonAnonymous(')
+
+      expect(tokens[0]).toEqual value: 'foo', scopes: ['source.js', 'meta.function.json.js', 'entity.name.function.js']
+      expect(tokens[2]).toEqual value: 'function', scopes: ['source.js', 'meta.function.json.js', 'storage.type.function.js']
+      expect(tokens[4]).toEqual value: 'nonAnonymous', scopes: ['source.js', 'meta.function.json.js', 'entity.name.function.js']
+      expect(tokens[5]).toEqual value: '(', scopes: ['source.js', 'meta.function.json.js', 'punctuation.definition.parameters.begin.js']
+
+    it "tokenizes quoted object functions", ->
+      {tokens} = grammar.tokenizeLine('"foo": function nonAnonymous(')
+
+      expect(tokens[1]) .toEqual value: 'foo', scopes: ['source.js', 'meta.function.json.js', 'string.quoted.double.js', 'entity.name.function.js']
+      expect(tokens[4]).toEqual value: 'function', scopes: ['source.js', 'meta.function.json.js', 'storage.type.function.js']
+      expect(tokens[6]).toEqual value: 'nonAnonymous', scopes: ['source.js', 'meta.function.json.js', 'entity.name.function.js']
+      expect(tokens[7]).toEqual value: '(', scopes: ['source.js', 'meta.function.json.js', 'punctuation.definition.parameters.begin.js']
+
   it "tokenizes /* */ comments", ->
     {tokens} = grammar.tokenizeLine('/**/')
 


### PR DESCRIPTION
The following cases will be properly recognized:

```javascript
Class.method = function nonAnonymous() {}
this.method = function nonAnonymous() {}
foo: function name() {}
```

Also added test case for fixed cases.

![non-anon-functions](https://cloud.githubusercontent.com/assets/350165/6888147/b836364a-d642-11e4-8cee-9ba9774c075a.gif)

This PR fixes https://github.com/github/linguist/issues/2284.