### PR TITLE
Added methods support

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -242,6 +242,9 @@
     ]
   }
   {
+    'include': '#methods'
+  }
+  {
     'match': '\\b(class)(?:(?:\\s+(extends)\\s+(\\w+(?:\\.\\w*)?))|(?:(?:\\s+(\\w+(?:\\.\\w*)?))(?:\\s+(extends)\\s+(\\w+(?:\\.\\w*)?))?))'
     'captures':
       '1':
@@ -519,6 +522,31 @@
             'include': '#interpolated_js'
           }
         ]
+      }
+    ]
+  'methods':
+    'patterns': [
+      {
+        'name': 'meta.method.js'
+        'comment': 'match regular function like: function myFunc(arg) { … }'
+
+        'begin': '\\b((?!(?:break|case|catch|continue|do|else|finally|for|function|if|export|import|package|return|switch|throw|try|while|with)[\\s\\(])(?:[a-zA-Z_$][a-zA-Z_$0-9]*))\\s*(\\()(?=(?:[^\\(\\)]*)?\\)\\s*\\{)'
+        'beginCaptures':
+          '1':
+            'name': 'entity.name.function.js'
+          '2':
+            'name': 'punctuation.definition.parameters.begin.js'
+
+        'patterns': [
+          {
+            'include': '#function-params'
+          }
+        ]
+
+        'end': '(\\))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.parameters.end.js'
       }
     ]
   'function-params':

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -235,6 +235,14 @@ describe "Javascript grammar", ->
       expect(tokens[8]).toEqual value: 'nonAnonymous', scopes: ['source.js', 'meta.function.js', 'entity.name.function.js']
       expect(tokens[9]).toEqual value: '(', scopes: ['source.js', 'meta.function.js', 'punctuation.definition.parameters.begin.js']
 
+    it "tokenizes methods", ->
+      {tokens} = grammar.tokenizeLine('f(a, b) {}')
+      expect(tokens[0]).toEqual value: 'f', scopes: ['source.js', 'meta.method.js', 'entity.name.function.js']
+      expect(tokens[1]).toEqual value: '(', scopes: ['source.js', 'meta.method.js', 'punctuation.definition.parameters.begin.js']
+      expect(tokens[2]).toEqual value: 'a', scopes: ['source.js', 'meta.method.js', 'variable.parameter.function.js']
+      expect(tokens[4]).toEqual value: 'b', scopes: ['source.js', 'meta.method.js', 'variable.parameter.function.js']
+      expect(tokens[5]).toEqual value: ')', scopes: ['source.js', 'meta.method.js', 'punctuation.definition.parameters.end.js']
+
     it "tokenizes functions", ->
       {tokens} = grammar.tokenizeLine('var func = function nonAnonymous(')
 


### PR DESCRIPTION
Highlighting of ES6 methods(functions without `function` keyword).
See [in sublime](https://github.com/babel/babel-sublime/blob/master/JavaScript%20%28Babel%29.tmLanguage#L1987)