### PR TITLE
Tokenize ALL_CAPS variables

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -372,8 +372,8 @@
     'name': 'constant.language.null.js'
   }
   {
-		'match': '(?<!\\.)\\b([A-Z][A-Z0-9_]+)(?!\\s*:)\\b'
-		'name': 'constant.other.js'
+    'match': '(?<!\\.)\\b([A-Z][A-Z0-9_]+)(?!\\s*:)\\b'
+    'name': 'constant.other.js'
   }
   {
     'match': '(?<!\\.)\\b(super|this)(?!\\s*:)\\b'

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -372,6 +372,10 @@
     'name': 'constant.language.null.js'
   }
   {
+		'match': '(?<!\\.)\\b([A-Z][A-Z0-9_]+)(?!\\s*:)\\b'
+		'name': 'constant.other.js'
+  }
+  {
     'match': '(?<!\\.)\\b(super|this)(?!\\s*:)\\b'
     'name': 'variable.language.js'
   }

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -100,14 +100,14 @@ describe "Javascript grammar", ->
       expect(lines[1][0]).toEqual value: '/ ', scopes: ['source.js']
       expect(lines[1][1]).toEqual value: '2', scopes: ['source.js', 'constant.numeric.js']
 
-    it "should tokenizes = correctly", ->
+    it "tokenizes = correctly", ->
       {tokens} = grammar.tokenizeLine('test = 2')
       expect(tokens[0]).toEqual value: 'test ', scopes: ['source.js']
       expect(tokens[1]).toEqual value: '=', scopes: ['source.js', 'keyword.operator.js']
       expect(tokens[2]).toEqual value: ' ', scopes: ['source.js']
       expect(tokens[3]).toEqual value: '2', scopes: ['source.js', 'constant.numeric.js']
 
-    it "should tokenizes + correctly", ->
+    it "tokenizes + correctly", ->
       {tokens} = grammar.tokenizeLine('test + 2')
       expect(tokens[0]).toEqual value: 'test ', scopes: ['source.js']
       expect(tokens[1]).toEqual value: '+', scopes: ['source.js', 'keyword.operator.js']
@@ -115,33 +115,42 @@ describe "Javascript grammar", ->
       expect(tokens[3]).toEqual value: '2', scopes: ['source.js', 'constant.numeric.js']
 
     describe "operators with 2 characters", ->
-      it "should tokenizes += correctly", ->
+      it "tokenizes += correctly", ->
         {tokens} = grammar.tokenizeLine('test += 2')
         expect(tokens[0]).toEqual value: 'test ', scopes: ['source.js']
         expect(tokens[1]).toEqual value: '+=', scopes: ['source.js', 'keyword.operator.js']
         expect(tokens[2]).toEqual value: ' ', scopes: ['source.js']
         expect(tokens[3]).toEqual value: '2', scopes: ['source.js', 'constant.numeric.js']
 
-      it "should tokenizes -= correctly", ->
+      it "tokenizes -= correctly", ->
         {tokens} = grammar.tokenizeLine('test -= 2')
         expect(tokens[0]).toEqual value: 'test ', scopes: ['source.js']
         expect(tokens[1]).toEqual value: '-=', scopes: ['source.js', 'keyword.operator.js']
         expect(tokens[2]).toEqual value: ' ', scopes: ['source.js']
         expect(tokens[3]).toEqual value: '2', scopes: ['source.js', 'constant.numeric.js']
 
-      it "should tokenizes *= correctly", ->
+      it "tokenizes *= correctly", ->
         {tokens} = grammar.tokenizeLine('test *= 2')
         expect(tokens[0]).toEqual value: 'test ', scopes: ['source.js']
         expect(tokens[1]).toEqual value: '*=', scopes: ['source.js', 'keyword.operator.js']
         expect(tokens[2]).toEqual value: ' ', scopes: ['source.js']
         expect(tokens[3]).toEqual value: '2', scopes: ['source.js', 'constant.numeric.js']
 
-      it "should tokenizes /= correctly", ->
+      it "tokenizes /= correctly", ->
         {tokens} = grammar.tokenizeLine('test /= 2')
         expect(tokens[0]).toEqual value: 'test ', scopes: ['source.js']
         expect(tokens[1]).toEqual value: '/=', scopes: ['source.js', 'keyword.operator.js']
         expect(tokens[2]).toEqual value: ' ', scopes: ['source.js']
         expect(tokens[3]).toEqual value: '2', scopes: ['source.js', 'constant.numeric.js']
+
+  describe "constants", ->
+    it "tokenizes ALL_CAPS variables correctly", ->
+      {tokens} = grammar.tokenizeLine('var MY_COOL_VAR = 42;')
+      expect(tokens[0]).toEqual value: 'var', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[1]).toEqual value: 'MY_COOL_VAR', scopes: ['source.js', 'constant.other.js']
+      expect(tokens[2]).toEqual value: '=', scopes: ['source.js', 'keyword.operator.js']
+      expect(tokens[3]).toEqual value: '42', scopes: ['source.js', 'constant.numeric.js']
+      expect(tokens[4]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
 
   describe "ES6 string templates", ->
     it "tokenizes them as strings", ->

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -147,10 +147,13 @@ describe "Javascript grammar", ->
     it "tokenizes ALL_CAPS variables correctly", ->
       {tokens} = grammar.tokenizeLine('var MY_COOL_VAR = 42;')
       expect(tokens[0]).toEqual value: 'var', scopes: ['source.js', 'storage.modifier.js']
-      expect(tokens[1]).toEqual value: 'MY_COOL_VAR', scopes: ['source.js', 'constant.other.js']
-      expect(tokens[2]).toEqual value: '=', scopes: ['source.js', 'keyword.operator.js']
-      expect(tokens[3]).toEqual value: '42', scopes: ['source.js', 'constant.numeric.js']
-      expect(tokens[4]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
+      expect(tokens[1]).toEqual value: ' ', scopes: ['source.js']
+      expect(tokens[2]).toEqual value: 'MY_COOL_VAR', scopes: ['source.js', 'constant.other.js']
+      expect(tokens[3]).toEqual value: ' ', scopes: ['source.js']
+      expect(tokens[4]).toEqual value: '=', scopes: ['source.js', 'keyword.operator.js']
+      expect(tokens[5]).toEqual value: ' ', scopes: ['source.js']
+      expect(tokens[6]).toEqual value: '42', scopes: ['source.js', 'constant.numeric.js']
+      expect(tokens[7]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
 
   describe "ES6 string templates", ->
     it "tokenizes them as strings", ->


### PR DESCRIPTION
Things like `MY_COOL_VAR` are now tokenized under `constant.other.js` (which could be `constant.other.global.js`, wasn't sure which one was best).  Also be aware I'm not too familiar with JS so this PR could totally be on the wrong track.

First time I managed to get a language spec I wrote to pass :smile:.

Refs #137.