### PR TITLE
Tokenize variables declared using const as constants

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -339,7 +339,7 @@
     'name': 'storage.modifier.js'
   }
   {
-    'match': '(?<!\\.)\\b(const)(?!\\s*:)\\b\\s+(\\w+)'
+    'match': '(?<!\\.)\\b(const)(?!\\s*:)\\b\\s+([$_a-zA-Z][[$_a-zA-Z0-9]*)'
     'captures':
       '1':
         'name': 'storage.modifier.js'

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -262,13 +262,13 @@
       '1':
         'name': 'storage.type.class.js'
       '2':
-        'name': 'storage.modifier.js',
+        'name': 'storage.modifier.js'
       '3':
         'name': 'entity.name.type.js'
       '4':
         'name': 'entity.name.type.js'
       '5':
-        'name': 'storage.modifier.js',
+        'name': 'storage.modifier.js'
       '6':
         'name': 'entity.name.type.js'
     'name': 'meta.class.js'
@@ -335,8 +335,16 @@
     'name': 'storage.type.js'
   }
   {
-    'match': '(?<!\\.)\\b(const|export|extends|implements|let|private|protected|public|static|var)(?!\\s*:)\\b'
+    'match': '(?<!\\.)\\b(export|extends|implements|let|private|protected|public|static|var)(?!\\s*:)\\b'
     'name': 'storage.modifier.js'
+  }
+  {
+    'match': '(?<!\\.)\\b(const)(?!\\s*:)\\b\\s+(\\w+)'
+    'captures':
+      '1':
+        'name': 'storage.modifier.js'
+      '2':
+        'name': 'constant.other.js'
   }
   {
     'match': '(?<!\\.)\\b(yield)(?!\\s*:)\\b(?:\\s*(\\*))?',

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -339,7 +339,7 @@
     'name': 'storage.modifier.js'
   }
   {
-    'match': '(?<!\\.)\\b(const)(?!\\s*:)\\b\\s+([$_a-zA-Z][[$_a-zA-Z0-9]*)'
+    'match': '(?<!\\.)\\b(const)(?!\\s*:)\\b\\s+([$_a-zA-Z][$_a-zA-Z0-9]*)'
     'captures':
       '1':
         'name': 'storage.modifier.js'

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -144,11 +144,33 @@ describe "Javascript grammar", ->
         expect(tokens[3]).toEqual value: '2', scopes: ['source.js', 'constant.numeric.js']
 
   describe "constants", ->
-    it "tokenizes ALL_CAPS variables correctly", ->
+    it "tokenizes ALL_CAPS variables as constants", ->
       {tokens} = grammar.tokenizeLine('var MY_COOL_VAR = 42;')
       expect(tokens[0]).toEqual value: 'var', scopes: ['source.js', 'storage.modifier.js']
       expect(tokens[1]).toEqual value: ' ', scopes: ['source.js']
       expect(tokens[2]).toEqual value: 'MY_COOL_VAR', scopes: ['source.js', 'constant.other.js']
+      expect(tokens[3]).toEqual value: ' ', scopes: ['source.js']
+      expect(tokens[4]).toEqual value: '=', scopes: ['source.js', 'keyword.operator.js']
+      expect(tokens[5]).toEqual value: ' ', scopes: ['source.js']
+      expect(tokens[6]).toEqual value: '42', scopes: ['source.js', 'constant.numeric.js']
+      expect(tokens[7]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
+
+      {tokens} = grammar.tokenizeLine('something = MY_COOL_VAR * 1;')
+      expect(tokens[0]).toEqual value: 'something ', scopes: ['source.js']
+      expect(tokens[1]).toEqual value: '=', scopes: ['source.js', 'keyword.operator.js']
+      expect(tokens[2]).toEqual value: ' ', scopes: ['source.js']
+      expect(tokens[3]).toEqual value: 'MY_COOL_VAR', scopes: ['source.js', 'constant.other.js']
+      expect(tokens[4]).toEqual value: ' ', scopes: ['source.js']
+      expect(tokens[5]).toEqual value: '*', scopes: ['source.js', 'keyword.operator.js']
+      expect(tokens[6]).toEqual value: ' ', scopes: ['source.js']
+      expect(tokens[7]).toEqual value: '1', scopes: ['source.js', 'constant.numeric.js']
+      expect(tokens[8]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
+
+    it "tokenizes variables declared using `const` as constants", ->
+      {tokens} = grammar.tokenizeLine('const myCoolVar = 42;')
+      expect(tokens[0]).toEqual value: 'const', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[1]).toEqual value: ' ', scopes: ['source.js']
+      expect(tokens[2]).toEqual value: 'myCoolVar', scopes: ['source.js', 'constant.other.js']
       expect(tokens[3]).toEqual value: ' ', scopes: ['source.js']
       expect(tokens[4]).toEqual value: '=', scopes: ['source.js', 'keyword.operator.js']
       expect(tokens[5]).toEqual value: ' ', scopes: ['source.js']


### PR DESCRIPTION
The `myCoolVar` in `const myCoolVar = 42` will now be tokenized as a constant.
Unfortunately this doesn't affect tokenization after the declaration...
```js
const myCoolVar = 42;  //Works!  constant.other.js
var something = 0;

something = myCoolVar * 1;  //Doesn't work :(
```
Again, refs #137.  Also, cc @kevinsawicki.