### PR TITLE
Fix not tokenizing operators in object functions

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -186,19 +186,21 @@
     ]
   }
   {
-    'begin': '\\b([a-zA-Z_?.$][\\w?.$]*)\\s*:\\s*\\b(?:(async)(?:\\s+))?(function\\*?)\\s*(\\*?)\\s*([a-zA-Z_?$][\\w?$]*)?\\s*(\\()'
+    'begin': '\\b([a-zA-Z_?.$][\\w?.$]*)\\s*(:)\\s*\\b(?:(async)(?:\\s+))?(function\\*?)\\s*(\\*?)\\s*([a-zA-Z_?$][\\w?$]*)?\\s*(\\()'
     'beginCaptures':
       '1':
         'name': 'entity.name.function.js'
       '2':
-        'name': 'storage.modifier.js'
+        'name': 'keyword.operator.js'
       '3':
-        'name': 'storage.type.function.js'
+        'name': 'storage.modifier.js'
       '4':
         'name': 'storage.type.function.js'
       '5':
-        'name': 'entity.name.function.js'
+        'name': 'storage.type.function.js'
       '6':
+        'name': 'entity.name.function.js'
+      '7':
         'name': 'punctuation.definition.parameters.begin.js'
     'comment': 'match stuff like: foobar: function() { … }'
     'end': '(\\))'
@@ -213,7 +215,7 @@
     ]
   }
   {
-    'begin': '(?:((\')(.*?)(\'))|((")(.*?)(")))\\s*:\\s*\\b(?:(async)(?:\\s+))?(function\\*?)\\s*(\\*?)\\s*([a-zA-Z_?$][\\w?$]*)?\\s*(\\()'
+    'begin': '(?:((\')(.*?)(\'))|((")(.*?)(")))\\s*(:)\\s*\\b(?:(async)(?:\\s+))?(function\\*?)\\s*(\\*?)\\s*([a-zA-Z_?$][\\w?$]*)?\\s*(\\()'
     'beginCaptures':
       '1':
         'name': 'string.quoted.single.js'
@@ -232,14 +234,16 @@
       '8':
         'name': 'punctuation.definition.string.end.js'
       '9':
-        'name': 'storage.modifier.js'
+        'name': 'keyword.operator.js'
       '10':
-        'name': 'storage.type.function.js'
+        'name': 'storage.modifier.js'
       '11':
         'name': 'storage.type.function.js'
       '12':
-        'name': 'entity.name.function.js'
+        'name': 'storage.type.function.js'
       '13':
+        'name': 'entity.name.function.js'
+      '14':
         'name': 'punctuation.definition.parameters.begin.js'
     'comment': 'Attempt to match "foo": function'
     'end': '(\\))'

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -278,11 +278,11 @@ describe "Javascript grammar", ->
   it "tokenizes comments in function params", ->
     {tokens} = grammar.tokenizeLine('foo: function (/**Bar*/bar){')
 
-    expect(tokens[4]).toEqual value: '(', scopes: ['source.js', 'meta.function.json.js', 'punctuation.definition.parameters.begin.js']
-    expect(tokens[5]).toEqual value: '/**', scopes: ['source.js', 'meta.function.json.js', 'comment.block.documentation.js', 'punctuation.definition.comment.js']
-    expect(tokens[6]).toEqual value: 'Bar', scopes: ['source.js', 'meta.function.json.js', 'comment.block.documentation.js']
-    expect(tokens[7]).toEqual value: '*/', scopes: ['source.js', 'meta.function.json.js', 'comment.block.documentation.js', 'punctuation.definition.comment.js']
-    expect(tokens[8]).toEqual value: 'bar', scopes: ['source.js', 'meta.function.json.js', 'variable.parameter.function.js']
+    expect(tokens[5]).toEqual value: '(', scopes: ['source.js', 'meta.function.json.js', 'punctuation.definition.parameters.begin.js']
+    expect(tokens[6]).toEqual value: '/**', scopes: ['source.js', 'meta.function.json.js', 'comment.block.documentation.js', 'punctuation.definition.comment.js']
+    expect(tokens[7]).toEqual value: 'Bar', scopes: ['source.js', 'meta.function.json.js', 'comment.block.documentation.js']
+    expect(tokens[8]).toEqual value: '*/', scopes: ['source.js', 'meta.function.json.js', 'comment.block.documentation.js', 'punctuation.definition.comment.js']
+    expect(tokens[9]).toEqual value: 'bar', scopes: ['source.js', 'meta.function.json.js', 'variable.parameter.function.js']
 
   describe "non-anonymous functions", ->
     it "tokenizes methods", ->
@@ -317,17 +317,19 @@ describe "Javascript grammar", ->
       {tokens} = grammar.tokenizeLine('foo: function nonAnonymous(')
 
       expect(tokens[0]).toEqual value: 'foo', scopes: ['source.js', 'meta.function.json.js', 'entity.name.function.js']
-      expect(tokens[2]).toEqual value: 'function', scopes: ['source.js', 'meta.function.json.js', 'storage.type.function.js']
-      expect(tokens[4]).toEqual value: 'nonAnonymous', scopes: ['source.js', 'meta.function.json.js', 'entity.name.function.js']
-      expect(tokens[5]).toEqual value: '(', scopes: ['source.js', 'meta.function.json.js', 'punctuation.definition.parameters.begin.js']
+      expect(tokens[1]).toEqual value: ':', scopes: ['source.js', 'meta.function.json.js', 'keyword.operator.js']
+      expect(tokens[3]).toEqual value: 'function', scopes: ['source.js', 'meta.function.json.js', 'storage.type.function.js']
+      expect(tokens[5]).toEqual value: 'nonAnonymous', scopes: ['source.js', 'meta.function.json.js', 'entity.name.function.js']
+      expect(tokens[6]).toEqual value: '(', scopes: ['source.js', 'meta.function.json.js', 'punctuation.definition.parameters.begin.js']
 
     it "tokenizes quoted object functions", ->
       {tokens} = grammar.tokenizeLine('"foo": function nonAnonymous(')
 
-      expect(tokens[1]) .toEqual value: 'foo', scopes: ['source.js', 'meta.function.json.js', 'string.quoted.double.js', 'entity.name.function.js']
-      expect(tokens[4]).toEqual value: 'function', scopes: ['source.js', 'meta.function.json.js', 'storage.type.function.js']
-      expect(tokens[6]).toEqual value: 'nonAnonymous', scopes: ['source.js', 'meta.function.json.js', 'entity.name.function.js']
-      expect(tokens[7]).toEqual value: '(', scopes: ['source.js', 'meta.function.json.js', 'punctuation.definition.parameters.begin.js']
+      expect(tokens[1]).toEqual value: 'foo', scopes: ['source.js', 'meta.function.json.js', 'string.quoted.double.js', 'entity.name.function.js']
+      expect(tokens[3]).toEqual value: ':', scopes: ['source.js', 'meta.function.json.js', 'keyword.operator.js']
+      expect(tokens[5]).toEqual value: 'function', scopes: ['source.js', 'meta.function.json.js', 'storage.type.function.js']
+      expect(tokens[7]).toEqual value: 'nonAnonymous', scopes: ['source.js', 'meta.function.json.js', 'entity.name.function.js']
+      expect(tokens[8]).toEqual value: '(', scopes: ['source.js', 'meta.function.json.js', 'punctuation.definition.parameters.begin.js']
 
     it "tokenizes async functions", ->
       {tokens} = grammar.tokenizeLine('async function f(){}')


### PR DESCRIPTION
Previous, `:` was not scoped at all for object functions.
```javascript
var a = {
  hello: 'testing',
  foo: function() {},
  "testing": function() {}
}
```
The `:` in `foo: function() {}` and `"testing": function() {}` had no scope originally. This PR scopes the `:` to `keyword.operator.js` to match the scope of other `:` in objects.