### PR TITLE
Adding JSM file as an extension

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -5,6 +5,7 @@
   '_js'
   'es'
   'es6'
+  'jsm'
   'pjs'
   'xsjs'
   'xsjslib'


### PR DESCRIPTION
`.jsm` files are Javascript modules used by Firefox and extensions:
https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules