### PR TITLE
Correctly mark $ prefixed vars as instance constructors

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -303,7 +303,7 @@
         'name': 'keyword.operator.new.js'
       '2':
         'name': 'entity.name.type.instance.js'
-    'match': '(new)\\s+(\\w+(?:\\.\\w*)?)'
+    'match': '(new)\\s+(\\$?\\w+(?:\\.\\w*)?)'
     'name': 'meta.class.instance.constructor'
   }
   {

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -48,16 +48,19 @@ describe "Javascript grammar", ->
   describe "instantiation", ->
     it "tokenizes the new keyword and instance entities", ->
       {tokens} = grammar.tokenizeLine('new something')
-      expect(tokens[0]).toEqual value: 'new', scopes: ['source.js', 'keyword.operator.new.js']
-      expect(tokens[1]).toEqual value: 'something', scopes: ['source.js', 'entity.instance.js']
+      expect(tokens[0]).toEqual value: 'new', scopes: ['source.js', 'meta.class.instance.constructor', 'keyword.operator.new.js']
+      expect(tokens[1]).toEqual value: ' ', scopes: ['source.js', 'meta.class.instance.constructor']
+      expect(tokens[2]).toEqual value: 'something', scopes: ['source.js', 'meta.class.instance.constructor', 'entity.instance.js']
 
       {tokens} = grammar.tokenizeLine('new Something')
-      expect(tokens[0]).toEqual value: 'new', scopes: ['source.js', 'keyword.operator.new.js']
-      expect(tokens[1]).toEqual value: 'Something', scopes: ['source.js', 'entity.instance.js']
+      expect(tokens[0]).toEqual value: 'new', scopes: ['source.js', 'meta.class.instance.constructor', 'keyword.operator.new.js']
+      expect(tokens[1]).toEqual value: ' ', scopes: ['source.js', 'meta.class.instance.constructor']
+      expect(tokens[2]).toEqual value: 'Something', scopes: ['source.js', 'meta.class.instance.constructor', 'entity.instance.js']
 
       {tokens} = grammar.tokenizeLine('new $something')
-      expect(tokens[0]).toEqual value: 'new', scopes: ['source.js', 'keyword.operator.new.js']
-      expect(tokens[1]).toEqual value: '$something', scopes: ['source.js', 'entity.instance.js']
+      expect(tokens[0]).toEqual value: 'new', scopes: ['source.js', 'meta.class.instance.constructor', 'keyword.operator.new.js']
+      expect(tokens[1]).toEqual value: ' ', scopes: ['source.js', 'meta.class.instance.constructor']
+      expect(tokens[2]).toEqual value: '$something', scopes: ['source.js', 'meta.class.instance.constructor', 'entity.instance.js']
 
   describe "regular expressions", ->
     it "tokenizes regular expressions", ->

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -50,17 +50,17 @@ describe "Javascript grammar", ->
       {tokens} = grammar.tokenizeLine('new something')
       expect(tokens[0]).toEqual value: 'new', scopes: ['source.js', 'meta.class.instance.constructor', 'keyword.operator.new.js']
       expect(tokens[1]).toEqual value: ' ', scopes: ['source.js', 'meta.class.instance.constructor']
-      expect(tokens[2]).toEqual value: 'something', scopes: ['source.js', 'meta.class.instance.constructor', 'entity.instance.js']
+      expect(tokens[2]).toEqual value: 'something', scopes: ['source.js', 'meta.class.instance.constructor', 'entity.name.type.instance.js']
 
       {tokens} = grammar.tokenizeLine('new Something')
       expect(tokens[0]).toEqual value: 'new', scopes: ['source.js', 'meta.class.instance.constructor', 'keyword.operator.new.js']
       expect(tokens[1]).toEqual value: ' ', scopes: ['source.js', 'meta.class.instance.constructor']
-      expect(tokens[2]).toEqual value: 'Something', scopes: ['source.js', 'meta.class.instance.constructor', 'entity.instance.js']
+      expect(tokens[2]).toEqual value: 'Something', scopes: ['source.js', 'meta.class.instance.constructor', 'entity.name.type.instance.js']
 
       {tokens} = grammar.tokenizeLine('new $something')
       expect(tokens[0]).toEqual value: 'new', scopes: ['source.js', 'meta.class.instance.constructor', 'keyword.operator.new.js']
       expect(tokens[1]).toEqual value: ' ', scopes: ['source.js', 'meta.class.instance.constructor']
-      expect(tokens[2]).toEqual value: '$something', scopes: ['source.js', 'meta.class.instance.constructor', 'entity.instance.js']
+      expect(tokens[2]).toEqual value: '$something', scopes: ['source.js', 'meta.class.instance.constructor', 'entity.name.type.instance.js']
 
   describe "regular expressions", ->
     it "tokenizes regular expressions", ->

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -45,6 +45,20 @@ describe "Javascript grammar", ->
       {tokens} = grammar.tokenizeLine('$window')
       expect(tokens[0]).toEqual value: '$window', scopes: ['source.js']
 
+  describe "instantiation", ->
+    it "tokenizes the new keyword and instance entities", ->
+      {tokens} = grammar.tokenizeLine('new something')
+      expect(tokens[0]).toEqual value: 'new', scopes: ['source.js', 'keyword.operator.new.js']
+      expect(tokens[1]).toEqual value: 'something', scopes: ['source.js', 'entity.instance.js']
+
+      {tokens} = grammar.tokenizeLine('new Something')
+      expect(tokens[0]).toEqual value: 'new', scopes: ['source.js', 'keyword.operator.new.js']
+      expect(tokens[1]).toEqual value: 'Something', scopes: ['source.js', 'entity.instance.js']
+
+      {tokens} = grammar.tokenizeLine('new $something')
+      expect(tokens[0]).toEqual value: 'new', scopes: ['source.js', 'keyword.operator.new.js']
+      expect(tokens[1]).toEqual value: '$something', scopes: ['source.js', 'entity.instance.js']
+
   describe "regular expressions", ->
     it "tokenizes regular expressions", ->
       {tokens} = grammar.tokenizeLine('/test/')


### PR DESCRIPTION
E.g. `new $thing()` 
It will now mark $thing as an instance constructor.