### PR TITLE
Add support for destructuring in const assignments

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -363,12 +363,49 @@
     'name': 'storage.modifier.js'
   }
   {
-    'match': '(?<!\\.)\\b(const)(?!\\s*:)\\b\\s+([$_a-zA-Z][$_a-zA-Z0-9]*)'
-    'captures':
+    'begin': '(?<!\\.)\\b(const)(?!\\s*:)\\b\\s+'
+    'beginCaptures':
       '1':
         'name': 'storage.modifier.js'
-      '2':
-        'name': 'constant.other.js'
+    'end': '(=)\\s+'
+    'endCaptures':
+      '1':
+        'name': 'keyword.operator.js'
+    'patterns': [
+      {
+        'match': '([$_a-zA-Z][$_a-zA-Z0-9]*)\\s*(:)\\s*([$_a-zA-Z][$_a-zA-Z0-9]*)?'
+        'captures':
+          '2':
+            'name': 'keyword.operator.js'
+          '3':
+            'name': 'constant.other.js'
+      }
+      {
+        'match': '([$_a-zA-Z][$_a-zA-Z0-9]*)'
+        'captures':
+          '1':
+            'name': 'constant.other.js'
+      }
+      {
+        'match': '\\.\\.\\.'
+        'name': 'meta.delimiter.object.spread.js'
+      }
+      {
+        'match': ','
+        'name': 'meta.delimiter.object.comma.js'
+      }
+      {
+        'match': '\\{|\\}'
+        'name': 'meta.brace.curly.js'
+      }
+      {
+        'match': '\\[|\\]'
+        'name': 'meta.brace.square.js'
+      }
+      {
+        'match': '\\s+'
+      }
+    ]
   }
   {
     'match': '(?<!\\.)\\b(yield)(?!\\s*:)\\b(?:\\s*(\\*))?',

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -388,7 +388,7 @@
       }
       {
         'match': '\\.\\.\\.'
-        'name': 'meta.delimiter.object.spread.js'
+        'name': 'keyword.operator.js'
       }
       {
         'match': ','

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -195,6 +195,25 @@ describe "Javascript grammar", ->
       expect(tokens[6]).toEqual value: '42', scopes: ['source.js', 'constant.numeric.js']
       expect(tokens[7]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
 
+      {tokens} = grammar.tokenizeLine('const {first:f,second,...rest} = obj;')
+      expect(tokens[0]).toEqual value: 'const', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[1]).toEqual value: ' ', scopes: ['source.js']
+      expect(tokens[2]).toEqual value: '{', scopes: ['source.js', 'meta.brace.curly.js']
+      expect(tokens[3]).toEqual value: 'first', scopes: ['source.js']
+      expect(tokens[4]).toEqual value: ':', scopes: ['source.js', 'keyword.operator.js']
+      expect(tokens[5]).toEqual value: 'f', scopes: ['source.js', 'constant.other.js']
+      expect(tokens[6]).toEqual value: ',', scopes: ['source.js', 'meta.delimiter.object.comma.js']
+      expect(tokens[7]).toEqual value: 'second', scopes: ['source.js', 'constant.other.js']
+      expect(tokens[8]).toEqual value: ',', scopes: ['source.js', 'meta.delimiter.object.comma.js']
+      expect(tokens[9]).toEqual value: '...', scopes: ['source.js', 'meta.delimiter.object.spread.js']
+      expect(tokens[10]).toEqual value: 'rest', scopes: ['source.js', 'constant.other.js']
+      expect(tokens[11]).toEqual value: '}', scopes: ['source.js', 'meta.brace.curly.js']
+      expect(tokens[12]).toEqual value: ' ', scopes: ['source.js']
+      expect(tokens[13]).toEqual value: '=', scopes: ['source.js', 'keyword.operator.js']
+      expect(tokens[14]).toEqual value: ' ', scopes: ['source.js']
+      expect(tokens[15]).toEqual value: 'obj', scopes: ['source.js']
+      expect(tokens[16]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
+
     it "tokenizes support constants", ->
       {tokens} = grammar.tokenizeLine('awesome = cool.systemLanguage;')
       expect(tokens[0]).toEqual value: 'awesome ', scopes: ['source.js']

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -205,7 +205,7 @@ describe "Javascript grammar", ->
       expect(tokens[6]).toEqual value: ',', scopes: ['source.js', 'meta.delimiter.object.comma.js']
       expect(tokens[7]).toEqual value: 'second', scopes: ['source.js', 'constant.other.js']
       expect(tokens[8]).toEqual value: ',', scopes: ['source.js', 'meta.delimiter.object.comma.js']
-      expect(tokens[9]).toEqual value: '...', scopes: ['source.js', 'meta.delimiter.object.spread.js']
+      expect(tokens[9]).toEqual value: '...', scopes: ['source.js', 'keyword.operator.js']
       expect(tokens[10]).toEqual value: 'rest', scopes: ['source.js', 'constant.other.js']
       expect(tokens[11]).toEqual value: '}', scopes: ['source.js', 'meta.brace.curly.js']
       expect(tokens[12]).toEqual value: ' ', scopes: ['source.js']


### PR DESCRIPTION
I am tired of how the syntax highlighting of constant identifiers breaks when the `const` keyword is combined with destructuring assignment.

This is the current behaviour:
![screen shot 2015-07-23 at 14 00 24](https://cloud.githubusercontent.com/assets/703602/8849858/3f3568fe-3143-11e5-84c1-c8d2d463ccab.png)

Behaviour as of this PR:
![screen shot 2015-07-23 at 14 06 41](https://cloud.githubusercontent.com/assets/703602/8849939/10a0a8fe-3144-11e5-996e-367c665ecd8d.png)

I would additionally like `d` to be properly highlighted as a constant above, but that will have to wait.