### PR TITLE
Fix highlighting issue when declaraing a const regex variable

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -367,7 +367,7 @@
     'beginCaptures':
       '1':
         'name': 'storage.modifier.js'
-    'end': '(=)\\s+'
+    'end': '(=)'
     'endCaptures':
       '1':
         'name': 'keyword.operator.js'

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -231,6 +231,18 @@ describe "Javascript grammar", ->
       expect(tokens[15]).toEqual value: 'obj', scopes: ['source.js']
       expect(tokens[16]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
 
+      {tokens} = grammar.tokenizeLine('const c = /regex/;')
+      expect(tokens[0]).toEqual value: 'const', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[1]).toEqual value: ' ', scopes: ['source.js']
+      expect(tokens[2]).toEqual value: 'c', scopes: ['source.js', 'constant.other.js']
+      expect(tokens[3]).toEqual value: ' ', scopes: ['source.js']
+      expect(tokens[4]).toEqual value: '=', scopes: ['source.js', 'keyword.operator.js']
+      expect(tokens[5]).toEqual value: ' ', scopes: ['source.js']
+      expect(tokens[6]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.begin.js']
+      expect(tokens[7]).toEqual value: 'regex', scopes: ['source.js', 'string.regexp.js']
+      expect(tokens[8]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.end.js']
+      expect(tokens[9]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
+
     it "tokenizes support constants", ->
       {tokens} = grammar.tokenizeLine('awesome = cool.systemLanguage;')
       expect(tokens[0]).toEqual value: 'awesome ', scopes: ['source.js']

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -227,9 +227,8 @@ describe "Javascript grammar", ->
       expect(tokens[11]).toEqual value: '}', scopes: ['source.js', 'meta.brace.curly.js']
       expect(tokens[12]).toEqual value: ' ', scopes: ['source.js']
       expect(tokens[13]).toEqual value: '=', scopes: ['source.js', 'keyword.operator.js']
-      expect(tokens[14]).toEqual value: ' ', scopes: ['source.js']
-      expect(tokens[15]).toEqual value: 'obj', scopes: ['source.js']
-      expect(tokens[16]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
+      expect(tokens[14]).toEqual value: ' obj', scopes: ['source.js']
+      expect(tokens[15]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
 
       {tokens} = grammar.tokenizeLine('const c = /regex/;')
       expect(tokens[0]).toEqual value: 'const', scopes: ['source.js', 'storage.modifier.js']
@@ -237,7 +236,7 @@ describe "Javascript grammar", ->
       expect(tokens[2]).toEqual value: 'c', scopes: ['source.js', 'constant.other.js']
       expect(tokens[3]).toEqual value: ' ', scopes: ['source.js']
       expect(tokens[4]).toEqual value: '=', scopes: ['source.js', 'keyword.operator.js']
-      expect(tokens[5]).toEqual value: ' ', scopes: ['source.js']
+      expect(tokens[5]).toEqual value: ' ', scopes: ['source.js', 'string.regexp.js']
       expect(tokens[6]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.begin.js']
       expect(tokens[7]).toEqual value: 'regex', scopes: ['source.js', 'string.regexp.js']
       expect(tokens[8]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.end.js']


### PR DESCRIPTION
My new `const` matchers broke regex highlighting (and possibly others). This PR addresses #176.

Before:
<img width="198" alt="screen shot 2015-07-25 at 15 05 54" src="https://cloud.githubusercontent.com/assets/703602/8889615/af6caea8-32e1-11e5-83b6-66aa9503854c.png" style="max-width:100%;">
After
<img width="223" alt="screen shot 2015-07-25 at 15 35 47" src="https://cloud.githubusercontent.com/assets/703602/8889636/03de04ae-32e3-11e5-8b9e-a1a67615ed08.png">