### PR TITLE
More const fixes

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -367,7 +367,7 @@
     'beginCaptures':
       '1':
         'name': 'storage.modifier.js'
-    'end': '(=|of|in)|(;)'
+    'end': '(=|of|in)|(;)|(?<!,)\\n'
     'endCaptures':
       '1':
         'name': 'keyword.operator.js'

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -363,7 +363,7 @@
     'name': 'storage.modifier.js'
   }
   {
-    'begin': '(?<!\\.)\\b(const)(?!\\s*:)\\b\\s+'
+    'begin': '(?<!\\.)\\b(const)(?!\\s*:)\\b'
     'beginCaptures':
       '1':
         'name': 'storage.modifier.js'
@@ -397,15 +397,16 @@
         'name': 'meta.delimiter.object.comma.js'
       }
       {
+        'match': '\\(|\\)'
+        'name': 'meta.brace.round.js'
+      }
+      {
         'match': '\\{|\\}'
         'name': 'meta.brace.curly.js'
       }
       {
         'match': '\\[|\\]'
         'name': 'meta.brace.square.js'
-      }
-      {
-        'match': '\\s+'
       }
     ]
   }

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -212,6 +212,14 @@ describe "Javascript grammar", ->
       expect(tokens[6]).toEqual value: '42', scopes: ['source.js', 'constant.numeric.js']
       expect(tokens[7]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
 
+      {tokens} = grammar.tokenizeLine('(const hi);')
+      expect(tokens[0]).toEqual value: '(', scopes: ['source.js', 'meta.brace.round.js']
+      expect(tokens[1]).toEqual value: 'const', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[2]).toEqual value: ' ', scopes: ['source.js']
+      expect(tokens[3]).toEqual value: 'hi', scopes: ['source.js', 'constant.other.js']
+      expect(tokens[4]).toEqual value: ')', scopes: ['source.js', 'meta.brace.round.js']
+      expect(tokens[5]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
+
       {tokens} = grammar.tokenizeLine('const {first:f,second,...rest} = obj;')
       expect(tokens[0]).toEqual value: 'const', scopes: ['source.js', 'storage.modifier.js']
       expect(tokens[1]).toEqual value: ' ', scopes: ['source.js']

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -212,6 +212,24 @@ describe "Javascript grammar", ->
       expect(tokens[6]).toEqual value: '42', scopes: ['source.js', 'constant.numeric.js']
       expect(tokens[7]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
 
+      lines = grammar.tokenizeLines """
+        const a,
+        b,
+        c
+        if(a)
+      """
+      expect(lines[0][0]).toEqual value: 'const', scopes: ['source.js', 'storage.modifier.js']
+      expect(lines[0][1]).toEqual value: ' ', scopes: ['source.js']
+      expect(lines[0][2]).toEqual value: 'a', scopes: ['source.js', 'constant.other.js']
+      expect(lines[0][3]).toEqual value: ',', scopes: ['source.js', 'meta.delimiter.object.comma.js']
+      expect(lines[1][0]).toEqual value: 'b', scopes: ['source.js', 'constant.other.js']
+      expect(lines[1][1]).toEqual value: ',', scopes: ['source.js', 'meta.delimiter.object.comma.js']
+      expect(lines[2][0]).toEqual value: 'c', scopes: ['source.js', 'constant.other.js']
+      expect(lines[3][0]).toEqual value: 'if', scopes: ['source.js', 'keyword.control.js']
+      expect(lines[3][1]).toEqual value: '(', scopes: ['source.js', 'meta.brace.round.js']
+      expect(lines[3][2]).toEqual value: 'a', scopes: ['source.js']
+      expect(lines[3][3]).toEqual value: ')', scopes: ['source.js', 'meta.brace.round.js']
+
       {tokens} = grammar.tokenizeLine('(const hi);')
       expect(tokens[0]).toEqual value: '(', scopes: ['source.js', 'meta.brace.round.js']
       expect(tokens[1]).toEqual value: 'const', scopes: ['source.js', 'storage.modifier.js']


### PR DESCRIPTION
Continuation of #181.

I also removed some unneeded whitespace matchers so that `const` gets highlighted the moment you finish typing it, not after you add a space (this is consistent with all the other regex rules).  There was also an orphaned whitespace matcher without a name, so I :fire:'d that as well.

/cc @Victorystick 