### PR TITLE
Add regexp replacement grammar

### DIFF
--- a/grammars/regular expression replacement (javascript).cson
+++ b/grammars/regular expression replacement (javascript).cson
@@ -1,0 +1,122 @@
+'fileTypes': []
+'hideFromUser': true
+'name': 'Regular Expressions (JavaScript)'
+'patterns': [
+  {
+    'include': '#regexp'
+  }
+]
+'repository':
+  'regex-character-class':
+    'patterns': [
+      {
+        'match': '\\\\[wWsSdD]|\\.'
+        'name': 'constant.character.character-class.regexp'
+      }
+      {
+        'match': '\\\\([0-7]{3}|x\\h\\h|u\\h\\h\\h\\h)'
+        'name': 'constant.character.numeric.regexp'
+      }
+      {
+        'match': '\\\\c[A-Z]'
+        'name': 'constant.character.control.regexp'
+      }
+      {
+        'match': '\\\\.'
+        'name': 'constant.character.escape.backslash.regexp'
+      }
+    ]
+  'regexp':
+    'patterns': [
+      {
+        'match': '\\\\[bB]|\\^|\\$'
+        'name': 'keyword.control.anchor.regexp'
+      }
+      {
+        'match': '\\\\[1-9]\\d*'
+        'name': 'keyword.other.back-reference.regexp'
+      }
+      {
+        'match': '[?+*]|\\{(\\d+,\\d+|\\d+,|,\\d+|\\d+)\\}\\??'
+        'name': 'keyword.operator.quantifier.regexp'
+      }
+      {
+        'match': '\\|'
+        'name': 'keyword.operator.or.regexp'
+      }
+      {
+        'begin': '(\\()((\\?=)|(\\?!))'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.definition.group.regexp'
+          '3':
+            'name': 'meta.assertion.look-ahead.regexp'
+          '4':
+            'name': 'meta.assertion.negative-look-ahead.regexp'
+        'end': '(\\))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.group.regexp'
+        'name': 'meta.group.assertion.regexp'
+        'patterns': [
+          {
+            'include': '#regexp'
+          }
+        ]
+      }
+      {
+        'begin': '\\((\\?:)?'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.group.regexp'
+        'end': '\\)'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.group.regexp'
+        'name': 'meta.group.regexp'
+        'patterns': [
+          {
+            'include': '#regexp'
+          }
+        ]
+      }
+      {
+        'begin': '(\\[)(\\^)?'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.definition.character-class.regexp'
+          '2':
+            'name': 'keyword.operator.negation.regexp'
+        'end': '(\\])'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.character-class.regexp'
+        'name': 'constant.other.character-class.set.regexp'
+        'patterns': [
+          {
+            'captures':
+              '1':
+                'name': 'constant.character.numeric.regexp'
+              '2':
+                'name': 'constant.character.control.regexp'
+              '3':
+                'name': 'constant.character.escape.backslash.regexp'
+              '4':
+                'name': 'constant.character.numeric.regexp'
+              '5':
+                'name': 'constant.character.control.regexp'
+              '6':
+                'name': 'constant.character.escape.backslash.regexp'
+            'match': '(?:.|(\\\\(?:[0-7]{3}|x\\h\\h|u\\h\\h\\h\\h))|(\\\\c[A-Z])|(\\\\.))\\-(?:[^\\]\\\\]|(\\\\(?:[0-7]{3}|x\\h\\h|u\\h\\h\\h\\h))|(\\\\c[A-Z])|(\\\\.))'
+            'name': 'constant.other.character-class.range.regexp'
+          }
+          {
+            'include': '#regex-character-class'
+          }
+        ]
+      }
+      {
+        'include': '#regex-character-class'
+      }
+    ]
+'scopeName': 'source.js.regexp'

--- a/grammars/regular expression replacement (javascript).cson
+++ b/grammars/regular expression replacement (javascript).cson
@@ -1,6 +1,6 @@
 'fileTypes': []
 'hideFromUser': true
-'name': 'Regular Expressions (JavaScript)'
+'name': 'Regular Expression Replacement (JavaScript)'
 'patterns': [
   {
     'include': '#regexp'
@@ -119,4 +119,4 @@
         'include': '#regex-character-class'
       }
     ]
-'scopeName': 'source.js.regexp'
+'scopeName': 'source.js.regexp.replacement'

--- a/grammars/regular expression replacement (javascript).cson
+++ b/grammars/regular expression replacement (javascript).cson
@@ -18,7 +18,7 @@
         'name': 'constant.character.escape.dollar.regexp.replacement'
       }
       {
-        'match': '\\\\.'
+        'match': '\\\\[^$]'
         'name': 'constant.character.escape.backslash.regexp.replacement'
       }
     ]

--- a/grammars/regular expression replacement (javascript).cson
+++ b/grammars/regular expression replacement (javascript).cson
@@ -3,120 +3,15 @@
 'name': 'Regular Expression Replacement (JavaScript)'
 'patterns': [
   {
-    'include': '#regexp'
+    'include': '#regexp-replacement'
   }
 ]
 'repository':
-  'regex-character-class':
+  'regexp-replacement':
     'patterns': [
-      {
-        'match': '\\\\[wWsSdD]|\\.'
-        'name': 'constant.character.character-class.regexp'
-      }
-      {
-        'match': '\\\\([0-7]{3}|x\\h\\h|u\\h\\h\\h\\h)'
-        'name': 'constant.character.numeric.regexp'
-      }
-      {
-        'match': '\\\\c[A-Z]'
-        'name': 'constant.character.control.regexp'
-      }
       {
         'match': '\\\\.'
         'name': 'constant.character.escape.backslash.regexp'
-      }
-    ]
-  'regexp':
-    'patterns': [
-      {
-        'match': '\\\\[bB]|\\^|\\$'
-        'name': 'keyword.control.anchor.regexp'
-      }
-      {
-        'match': '\\\\[1-9]\\d*'
-        'name': 'keyword.other.back-reference.regexp'
-      }
-      {
-        'match': '[?+*]|\\{(\\d+,\\d+|\\d+,|,\\d+|\\d+)\\}\\??'
-        'name': 'keyword.operator.quantifier.regexp'
-      }
-      {
-        'match': '\\|'
-        'name': 'keyword.operator.or.regexp'
-      }
-      {
-        'begin': '(\\()((\\?=)|(\\?!))'
-        'beginCaptures':
-          '1':
-            'name': 'punctuation.definition.group.regexp'
-          '3':
-            'name': 'meta.assertion.look-ahead.regexp'
-          '4':
-            'name': 'meta.assertion.negative-look-ahead.regexp'
-        'end': '(\\))'
-        'endCaptures':
-          '1':
-            'name': 'punctuation.definition.group.regexp'
-        'name': 'meta.group.assertion.regexp'
-        'patterns': [
-          {
-            'include': '#regexp'
-          }
-        ]
-      }
-      {
-        'begin': '\\((\\?:)?'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.group.regexp'
-        'end': '\\)'
-        'endCaptures':
-          '0':
-            'name': 'punctuation.definition.group.regexp'
-        'name': 'meta.group.regexp'
-        'patterns': [
-          {
-            'include': '#regexp'
-          }
-        ]
-      }
-      {
-        'begin': '(\\[)(\\^)?'
-        'beginCaptures':
-          '1':
-            'name': 'punctuation.definition.character-class.regexp'
-          '2':
-            'name': 'keyword.operator.negation.regexp'
-        'end': '(\\])'
-        'endCaptures':
-          '1':
-            'name': 'punctuation.definition.character-class.regexp'
-        'name': 'constant.other.character-class.set.regexp'
-        'patterns': [
-          {
-            'captures':
-              '1':
-                'name': 'constant.character.numeric.regexp'
-              '2':
-                'name': 'constant.character.control.regexp'
-              '3':
-                'name': 'constant.character.escape.backslash.regexp'
-              '4':
-                'name': 'constant.character.numeric.regexp'
-              '5':
-                'name': 'constant.character.control.regexp'
-              '6':
-                'name': 'constant.character.escape.backslash.regexp'
-            'match': '(?:.|(\\\\(?:[0-7]{3}|x\\h\\h|u\\h\\h\\h\\h))|(\\\\c[A-Z])|(\\\\.))\\-(?:[^\\]\\\\]|(\\\\(?:[0-7]{3}|x\\h\\h|u\\h\\h\\h\\h))|(\\\\c[A-Z])|(\\\\.))'
-            'name': 'constant.other.character-class.range.regexp'
-          }
-          {
-            'include': '#regex-character-class'
-          }
-        ]
-      }
-      {
-        'include': '#regex-character-class'
       }
     ]
 'scopeName': 'source.js.regexp.replacement'

--- a/grammars/regular expression replacement (javascript).cson
+++ b/grammars/regular expression replacement (javascript).cson
@@ -10,8 +10,16 @@
   'regexp-replacement':
     'patterns': [
       {
+        'match': '\\$[0-9]{1,2}|\\$[&`\']'
+        'name': 'variable.regexp.replacement'
+      }
+      {
+        'match': '\\$\\$'
+        'name': 'constant.character.escape.dollar.regexp.replacement'
+      }
+      {
         'match': '\\\\.'
-        'name': 'constant.character.escape.backslash.regexp'
+        'name': 'constant.character.escape.backslash.regexp.replacement'
       }
     ]
 'scopeName': 'source.js.regexp.replacement'

--- a/spec/regular-expression-replacement-spec.coffee
+++ b/spec/regular-expression-replacement-spec.coffee
@@ -1,0 +1,73 @@
+{TextEditor} = require 'atom'
+fs = require 'fs'
+path = require 'path'
+
+describe "Regular Expression Replacement grammar", ->
+  grammar = null
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage("language-javascript")
+
+    runs ->
+      grammar = atom.grammars.grammarForScopeName("source.js.regexp.replacement")
+
+  it "parses the grammar", ->
+    expect(grammar).toBeTruthy()
+    expect(grammar.scopeName).toBe "source.js.regexp.replacement"
+
+  describe "basic strings", ->
+    it "tokenizes with no extra scopes", ->
+      {tokens} = grammar.tokenizeLine('Hello [world]. (hi to you)')
+      expect(tokens[0]).toEqual value: 'Hello [world]. (hi to you)', scopes: ['source.js.regexp.replacement']
+
+  describe "escaped characters", ->
+    it "tokenizes with as an escape character", ->
+      {tokens} = grammar.tokenizeLine('\\n')
+      expect(tokens[0]).toEqual value: '\\n', scopes: ['source.js.regexp.replacement', 'constant.character.escape.backslash.regexp.replacement']
+
+    it "tokenizes '$$' as an escaped '$' character", ->
+      {tokens} = grammar.tokenizeLine('$$')
+      expect(tokens[0]).toEqual value: '$$', scopes: ['source.js.regexp.replacement', 'constant.character.escape.dollar.regexp.replacement']
+
+    it "doesn't treat '\\$' as an escaped '$' character", ->
+      {tokens} = grammar.tokenizeLine('\\$')
+      expect(tokens[0]).toEqual value: '\\$', scopes: ['source.js.regexp.replacement']
+
+    it "tokenizes '$$1' as an escaped '$' character followed by a '1' character", ->
+      {tokens} = grammar.tokenizeLine('$$1')
+      expect(tokens[0]).toEqual value: '$$', scopes: ['source.js.regexp.replacement', 'constant.character.escape.dollar.regexp.replacement']
+      expect(tokens[1]).toEqual value: '1', scopes: ['source.js.regexp.replacement']
+
+  describe "Numeric placeholders", ->
+    it "tokenizes $1 as a variable", ->
+      {tokens} = grammar.tokenizeLine('$1')
+      expect(tokens[0]).toEqual value: '$1', scopes: ['source.js.regexp.replacement', 'variable.regexp.replacement']
+
+    it "tokenizes $10 as a variable", ->
+      {tokens} = grammar.tokenizeLine('$10')
+      expect(tokens[0]).toEqual value: '$10', scopes: ['source.js.regexp.replacement', 'variable.regexp.replacement']
+
+    it "tokenizes $99 as a variable", ->
+      {tokens} = grammar.tokenizeLine('$99')
+      expect(tokens[0]).toEqual value: '$99', scopes: ['source.js.regexp.replacement', 'variable.regexp.replacement']
+
+    it "doesn't tokenize the third numberic character in '$100' as a variable", ->
+      {tokens} = grammar.tokenizeLine('$100')
+      expect(tokens[0]).toEqual value: '$10', scopes: ['source.js.regexp.replacement', 'variable.regexp.replacement']
+      expect(tokens[1]).toEqual value: '0', scopes: ['source.js.regexp.replacement']
+
+    describe "Matched sub-string placeholder", ->
+      it "tokenizes $& as a variable", ->
+        {tokens} = grammar.tokenizeLine('$&')
+        expect(tokens[0]).toEqual value: '$&', scopes: ['source.js.regexp.replacement', 'variable.regexp.replacement']
+
+    describe "Preceeding portion placeholder", ->
+      it "tokenizes $` as a variable", ->
+        {tokens} = grammar.tokenizeLine('$`')
+        expect(tokens[0]).toEqual value: '$`', scopes: ['source.js.regexp.replacement', 'variable.regexp.replacement']
+
+    describe "Following portion placeholder", ->
+      it "tokenizes $' as a variable", ->
+        {tokens} = grammar.tokenizeLine('$\'')
+        expect(tokens[0]).toEqual value: '$\'', scopes: ['source.js.regexp.replacement', 'variable.regexp.replacement']


### PR DESCRIPTION
This pull request adds support for highlighting regular expression replacement strings. Specifically it was created to support atom/find-and-replace#494 , adding syntax highlighting to the replacement editor of the find-and-replace dialog.

While this pull request does not (at this time) include support in-line tokenizing of the replacement strings within a Javascript source file, it could serve as the basis for that further work.