### PR TITLE
Improve support for line comments

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -341,23 +341,6 @@
     'include': '#comments'
   }
   {
-    'begin': '(^[ \\t]+)?(?=//)'
-    'beginCaptures':
-      '1':
-        'name': 'punctuation.whitespace.comment.leading.js'
-    'end': '(?!\\G)'
-    'patterns': [
-      {
-        'begin': '//'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.comment.js'
-        'end': '\\n'
-        'name': 'comment.line.double-slash.js'
-      }
-    ]
-  }
-  {
     'captures':
       '0':
         'name': 'punctuation.definition.comment.html.js'
@@ -744,5 +727,22 @@
             'name': 'punctuation.definition.comment.js'
         'end': '\\*/'
         'name': 'comment.block.js'
+      }
+      {
+        'begin': '(^[ \\t]+)?(?=//)'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.whitespace.comment.leading.js'
+        'end': '(?!\\G)'
+        'patterns': [
+          {
+            'begin': '//'
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.definition.comment.js'
+            'end': '\\n'
+            'name': 'comment.line.double-slash.js'
+          }
+        ]
       }
     ]

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -410,6 +410,9 @@
         'match': '\\[|\\]'
         'name': 'meta.brace.square.js'
       }
+      {
+        'include': '#comments'
+      }
     ]
   }
   {

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -23,6 +23,9 @@
         'include': '#strings'
       }
       {
+        'include': '#comments'
+      }
+      {
         'match': '\\b(as|from)\\b',
         'name': 'keyword.control.js'
       }

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -538,6 +538,14 @@ describe "Javascript grammar", ->
       expect(tokens[3]).toEqual value: ' ', scopes: ['source.js', 'comment.block.documentation.js']
       expect(tokens[4]).toEqual value: '*/', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.definition.comment.js']
 
+    it "tokenizes // comments", ->
+      {tokens} = grammar.tokenizeLine('import point; // comment')
+      expect(tokens[0]).toEqual value: 'import', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
+      expect(tokens[2]).toEqual value: 'point', scopes: ['source.js', 'meta.import.js']
+      expect(tokens[3]).toEqual value: '; ', scopes: ['source.js', 'meta.import.js']
+      expect(tokens[4]).toEqual value: '//', scopes: ['source.js', 'meta.import.js', 'comment.line.double-slash.js', 'punctuation.definition.comment.js']
+      expect(tokens[5]).toEqual value: ' comment', scopes: ['source.js', 'meta.import.js', 'comment.line.double-slash.js']
+
     it "tokenizes comments inside function parameters correctly", ->
       {tokens} = grammar.tokenizeLine('function test(arg1 /*, arg2 */) {}')
       expect(tokens[0]).toEqual value: 'function', scopes: ['source.js', 'meta.function.js', 'storage.type.function.js']

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -561,6 +561,15 @@ describe "Javascript grammar", ->
       expect(tokens[8]).toEqual value: '*/', scopes: ['source.js', 'meta.function.json.js', 'comment.block.documentation.js', 'punctuation.definition.comment.js']
       expect(tokens[9]).toEqual value: 'bar', scopes: ['source.js', 'meta.function.json.js', 'variable.parameter.function.js']
 
+      {tokens} = grammar.tokenizeLine('function test(bar, // comment')
+      expect(tokens[0]).toEqual value: 'function', scopes: ['source.js', 'meta.function.js', 'storage.type.function.js']
+      expect(tokens[2]).toEqual value: 'test', scopes: ['source.js', 'meta.function.js', 'entity.name.function.js']
+      expect(tokens[3]).toEqual value: '(', scopes: ['source.js', 'meta.function.js', 'punctuation.definition.parameters.begin.js']
+      expect(tokens[4]).toEqual value: 'bar', scopes: ['source.js', 'meta.function.js', 'variable.parameter.function.js']
+      expect(tokens[5]).toEqual value: ',', scopes: ['source.js', 'meta.function.js', 'meta.object.delimiter.js']
+      expect(tokens[7]).toEqual value: '//', scopes: ['source.js', 'meta.function.js', 'comment.line.double-slash.js', 'punctuation.definition.comment.js']
+      expect(tokens[8]).toEqual value: ' comment', scopes: ['source.js', 'meta.function.js', 'comment.line.double-slash.js']
+
   describe "indentation", ->
     editor = null
 

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -546,6 +546,14 @@ describe "Javascript grammar", ->
       expect(tokens[4]).toEqual value: '//', scopes: ['source.js', 'meta.import.js', 'comment.line.double-slash.js', 'punctuation.definition.comment.js']
       expect(tokens[5]).toEqual value: ' comment', scopes: ['source.js', 'meta.import.js', 'comment.line.double-slash.js']
 
+    it "tokenizes comments inside constant definitions", ->
+      {tokens} = grammar.tokenizeLine('const a, // comment')
+      expect(tokens[0]).toEqual value: 'const', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[2]).toEqual value: 'a', scopes: ['source.js', 'constant.other.js']
+      expect(tokens[3]).toEqual value: ',', scopes: ['source.js', 'meta.delimiter.object.comma.js']
+      expect(tokens[5]).toEqual value: '//', scopes: ['source.js', 'comment.line.double-slash.js', 'punctuation.definition.comment.js']
+      expect(tokens[6]).toEqual value: ' comment', scopes: ['source.js', 'comment.line.double-slash.js']
+
     it "tokenizes comments inside function parameters correctly", ->
       {tokens} = grammar.tokenizeLine('function test(arg1 /*, arg2 */) {}')
       expect(tokens[0]).toEqual value: 'function', scopes: ['source.js', 'meta.function.js', 'storage.type.function.js']


### PR DESCRIPTION
The first commit completes the fix for #70 (a3c3a07be56). Function arguments can now contain line comments.
The second commit fixes an issue reported in #137:
```js
import {x, y} as p from 'point';  // fixed in second commit
function test(arg1 = 0, // fixed in first commit
      arg2 = 1, arg3) {
}
```
See the [fix in Lightshow](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fpchaigno%2Flanguage-javascript%2F184dfc47c63cfc26cb4a79c41a11d8394aacd3bd%2Fgrammars%2Fjavascript.cson&grammar_text=&code_source=from-text&code_url=&code=import+{x%2C+y}+as+p+from+%27point%27%3B++%2F%2F+fixed+in+second+commit%0D%0Afunction+test%28arg1+%3D+0%2C+%2F%2F+fixed+in+first+commit%0D%0A++++++arg2+%3D+1%2C+arg3%29+{%0D%0A}).