### PR TITLE
Add support for stored arrowed function syntax highlighting

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -300,6 +300,29 @@
   }
   {
     'name': 'meta.function.arrow.js'
+    'begin': '([a-zA-Z_?$][\\w?$]*)\\s*(=)\\s*(\\()(?=(?:[^\\(\\)]*)?\\)\\s*=>)'
+    'beginCaptures':
+      '1':
+        'name': 'entity.name.function.js'
+      '2':
+        'name': 'keyword.operator.js'
+      '3':
+        'name': 'punctuation.definition.parameters.begin.js'
+    'comment': 'match stuff like: play = (a,b) => { … }'
+    'end': '(\\))(\\s*=>)'
+    'endCaptures':
+      '1':
+        'name': 'punctuation.definition.parameters.end.js'
+      '2':
+        'name': 'storage.type.arrow.js'
+    'patterns': [
+      {
+        'include': '#function-params'
+      }
+    ]
+  }
+  {
+    'name': 'meta.function.arrow.js'
     'begin': '(?<![A-Za-z0-9])(\\()(?=(?:[^\\(\\)]*)?\\)\\s*=>)'
     'beginCaptures':
       '1':

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -300,15 +300,11 @@
   }
   {
     'name': 'meta.function.arrow.js'
-    'begin': '([a-zA-Z_?$][\\w?$]*)\\s*(=)\\s*(\\()(?=(?:[^\\(\\)]*)?\\)\\s*=>)'
+    'begin': '(?<![A-Za-z0-9])(\\()(?=(?:[^\\(\\)]*)?\\)\\s*=>)'
     'beginCaptures':
       '1':
-        'name': 'entity.name.function.js'
-      '2':
-        'name': 'keyword.operator.js'
-      '3':
         'name': 'punctuation.definition.parameters.begin.js'
-    'comment': 'match stuff like: play = (a,b) => { … }'
+
     'end': '(\\))(\\s*=>)'
     'endCaptures':
       '1':
@@ -322,12 +318,16 @@
     ]
   }
   {
+    'comment': 'match stuff like: play = (a,b) => { … }'
     'name': 'meta.function.arrow.js'
-    'begin': '(?<![A-Za-z0-9])(\\()(?=(?:[^\\(\\)]*)?\\)\\s*=>)'
+    'begin': '([a-zA-Z_?$][\\w?$]*)\\s*(=)\\s*(\\()(?=(?:[^\\(\\)]*)?\\)\\s*=>)'
     'beginCaptures':
       '1':
+        'name': 'entity.name.function.js'
+      '2':
+        'name': 'keyword.operator.js'
+      '3':
         'name': 'punctuation.definition.parameters.begin.js'
-
     'end': '(\\))(\\s*=>)'
     'endCaptures':
       '1':

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -511,6 +511,16 @@ describe "Javascript grammar", ->
       expect(tokens[4]).toEqual value: ')', scopes: ['source.js', 'meta.function.arrow.js', 'punctuation.definition.parameters.end.js']
       expect(tokens[5]).toEqual value: '=>', scopes: ['source.js', 'meta.function.arrow.js', 'storage.type.arrow.js']
 
+    it "tokenizes stored arrow functions with params", ->
+      {tokens} = grammar.tokenizeLine('var func = (param1,param2)=>{}')
+      expect(tokens[0]).toEqual value: 'var', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[2]).toEqual value: 'func', scopes: ['source.js', 'meta.function.arrow.js', 'entity.name.function.js']
+      expect(tokens[4]).toEqual value: '=', scopes: ['source.js', 'meta.function.arrow.js', 'keyword.operator.js']
+      expect(tokens[7]).toEqual value: 'param1', scopes: ['source.js', 'meta.function.arrow.js', 'variable.parameter.function.js']
+      expect(tokens[9]).toEqual value: 'param2', scopes: ['source.js', 'meta.function.arrow.js', 'variable.parameter.function.js']
+      expect(tokens[10]).toEqual value: ')', scopes: ['source.js', 'meta.function.arrow.js', 'punctuation.definition.parameters.end.js']
+      expect(tokens[11]).toEqual value: '=>', scopes: ['source.js', 'meta.function.arrow.js', 'storage.type.arrow.js']
+
   describe "comments", ->
     it "tokenizes /* */ comments", ->
       {tokens} = grammar.tokenizeLine('/**/')


### PR DESCRIPTION
This commit expands es6 fat arrow support by adding syntax highlighting to stored fat arrow function declarations.

Before:
![screen shot 2015-08-25 at 11 28 14 pm](https://cloud.githubusercontent.com/assets/709042/9486843/1a3e2c86-4b81-11e5-9555-436f56876079.png)

After (foo and bar are tokenized):
![screen shot 2015-08-25 at 11 27 55 pm](https://cloud.githubusercontent.com/assets/709042/9486846/1e1c70b0-4b81-11e5-8238-90310376bf37.png)

