### PR TITLE
Highlight unescaped multiline strings as invalid

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -595,6 +595,10 @@
             'match': '\\\\(x\\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)'
             'name': 'constant.character.escape.js'
           }
+          {
+            'match': "[^']*[^\\n\\r'\\\\]$"
+            'name': 'invalid.illegal.string.js'
+          }
         ]
       }
       {
@@ -611,6 +615,10 @@
           {
             'match': '\\\\(x\\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]|37[0-7]?|[4-7][0-7]?|.)'
             'name': 'constant.character.escape.js'
+          }
+          {
+            'match': '[^"]*[^\\n\\r"\\\\]$'
+            'name': 'invalid.illegal.string.js'
           }
         ]
       }

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -31,6 +31,21 @@ describe "Javascript grammar", ->
         expect(tokens[2].value).toEqual delim
         expect(tokens[2].scopes).toEqual ["source.js", scope, "punctuation.definition.string.end.js"]
 
+    it "tokenizes invalid multiline strings", ->
+      lines = grammar.tokenizeLines("'line1\nline2\\\nline3'")
+      expect(lines[0][0]).toEqual value: "'", scopes: ['source.js', 'string.quoted.single.js', 'punctuation.definition.string.begin.js']
+      expect(lines[0][1]).toEqual value: 'line1', scopes: ['source.js', 'string.quoted.single.js', 'invalid.illegal.string.js']
+      expect(lines[1][0]).toEqual value: 'line2\\', scopes: ['source.js', 'string.quoted.single.js']
+      expect(lines[2][0]).toEqual value: 'line3', scopes: ['source.js', 'string.quoted.single.js']
+      expect(lines[2][1]).toEqual value: "'", scopes: ['source.js', 'string.quoted.single.js', 'punctuation.definition.string.end.js']
+
+      lines = grammar.tokenizeLines('"line1\nline2\\\nline3"')
+      expect(lines[0][0]).toEqual value: '"', scopes: ['source.js', 'string.quoted.double.js', 'punctuation.definition.string.begin.js']
+      expect(lines[0][1]).toEqual value: 'line1', scopes: ['source.js', 'string.quoted.double.js', 'invalid.illegal.string.js']
+      expect(lines[1][0]).toEqual value: 'line2\\', scopes: ['source.js', 'string.quoted.double.js']
+      expect(lines[2][0]).toEqual value: 'line3', scopes: ['source.js', 'string.quoted.double.js']
+      expect(lines[2][1]).toEqual value: '"', scopes: ['source.js', 'string.quoted.double.js', 'punctuation.definition.string.end.js']
+
   describe "keywords", ->
     it "tokenizes with as a keyword", ->
       {tokens} = grammar.tokenizeLine('with')

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -32,19 +32,21 @@ describe "Javascript grammar", ->
         expect(tokens[2].scopes).toEqual ["source.js", scope, "punctuation.definition.string.end.js"]
 
     it "tokenizes invalid multiline strings", ->
-      lines = grammar.tokenizeLines("'line1\nline2\\\nline3'")
-      expect(lines[0][0]).toEqual value: "'", scopes: ['source.js', 'string.quoted.single.js', 'punctuation.definition.string.begin.js']
-      expect(lines[0][1]).toEqual value: 'line1', scopes: ['source.js', 'string.quoted.single.js', 'invalid.illegal.string.js']
-      expect(lines[1][0]).toEqual value: 'line2\\', scopes: ['source.js', 'string.quoted.single.js']
-      expect(lines[2][0]).toEqual value: 'line3', scopes: ['source.js', 'string.quoted.single.js']
-      expect(lines[2][1]).toEqual value: "'", scopes: ['source.js', 'string.quoted.single.js', 'punctuation.definition.string.end.js']
+      delimsByScope =
+        "string.quoted.double.js": '"'
+        "string.quoted.single.js": "'"
 
-      lines = grammar.tokenizeLines('"line1\nline2\\\nline3"')
-      expect(lines[0][0]).toEqual value: '"', scopes: ['source.js', 'string.quoted.double.js', 'punctuation.definition.string.begin.js']
-      expect(lines[0][1]).toEqual value: 'line1', scopes: ['source.js', 'string.quoted.double.js', 'invalid.illegal.string.js']
-      expect(lines[1][0]).toEqual value: 'line2\\', scopes: ['source.js', 'string.quoted.double.js']
-      expect(lines[2][0]).toEqual value: 'line3', scopes: ['source.js', 'string.quoted.double.js']
-      expect(lines[2][1]).toEqual value: '"', scopes: ['source.js', 'string.quoted.double.js', 'punctuation.definition.string.end.js']
+      for scope, delim of delimsByScope
+        lines = grammar.tokenizeLines delim + """
+          line1
+          line2\\
+          line3
+        """ + delim
+        expect(lines[0][0]).toEqual value: delim, scopes: ['source.js', scope, 'punctuation.definition.string.begin.js']
+        expect(lines[0][1]).toEqual value: 'line1', scopes: ['source.js', scope, 'invalid.illegal.string.js']
+        expect(lines[1][0]).toEqual value: 'line2\\', scopes: ['source.js', scope]
+        expect(lines[2][0]).toEqual value: 'line3', scopes: ['source.js', scope]
+        expect(lines[2][1]).toEqual value: delim, scopes: ['source.js', scope, 'punctuation.definition.string.end.js']
 
   describe "keywords", ->
     it "tokenizes with as a keyword", ->


### PR DESCRIPTION
This pull request implements a change requested in #58.
Currently unescaped multiline strings are highlighted as if they were correct:
```js
'line1
line2\
line3'
```
This change will highlight such strings as invalid.
[Example of an invalid string with this change in Lightshow](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fpchaigno%2Flanguage-javascript%2Fa906d863677b8346aba3d429434a63747ac334ba%2Fgrammars%2Fjavascript.cson&grammar_text=&code_source=from-text&code_url=&code=%27line1%0D%0Aline2\\%0D%0Aline3%27).

/cc @Cydrobolt