### PR TITLE
Isolate periods in console methods

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -354,7 +354,7 @@
     'name': 'entity.name.type.object.js.console'
   }
   {
-    'match': '\\b(\\.)(assert|clear|debug|error|info|log|profile|profileEnd|time|timeEnd|warn)\\b(?=\\()'
+    'match': '\\b(\\.)(assert|clear|debug|error|info|log|profile|profileEnd|time|timeEnd|warn)(?=\\()'
     'captures':
       '1':
         'name': 'meta.delimiter.method.period.js'

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -354,8 +354,12 @@
     'name': 'entity.name.type.object.js.console'
   }
   {
-    'match': '\\.(warn|info|log|error|time|timeEnd|assert)\\b'
-    'name': 'support.function.js.console'
+    'match': '\\b(\\.)(assert|clear|debug|error|info|log|profile|profileEnd|time|timeEnd|warn)\\b(?=\\()'
+    'captures':
+      '1':
+        'name': 'meta.delimiter.method.period.js'
+      '2':
+        'name': 'support.function.js.console'
   }
   {
     'include': '#numbers'

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -614,6 +614,19 @@ describe "Javascript grammar", ->
       expect(tokens[7]).toEqual value: '//', scopes: ['source.js', 'meta.function.js', 'comment.line.double-slash.js', 'punctuation.definition.comment.js']
       expect(tokens[8]).toEqual value: ' comment', scopes: ['source.js', 'meta.function.js', 'comment.line.double-slash.js']
 
+  describe "console", ->
+    it "tokenizes the console keyword", ->
+      {tokens} = grammar.tokenizeLine('console')
+      expect(tokens[0]).toEqual value: 'console', scopes: ['source.js', 'entity.name.type.object.js.console']
+
+    it "tokenizes console support functions", ->
+      {tokens} = grammar.tokenizeLine('console.log()')
+      expect(tokens[0]).toEqual value: 'console', scopes: ['source.js', 'entity.name.type.object.js.console']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.method.period.js']
+      expect(tokens[2]).toEqual value: 'log', scopes: ['source.js', 'support.function.js.console']
+      expect(tokens[3]).toEqual value: '(', scopes: ['source.js', 'meta.brace.round.js']
+      expect(tokens[4]).toEqual value: ')', scopes: ['source.js', 'meta.brace.round.js']
+
   describe "indentation", ->
     editor = null
 


### PR DESCRIPTION
Also adds some more support functions and adds some safeguards (eg `.log()` isn't valid anymore and neither is `console.log` - it has to be `something.log()`).

Fixes #213