### PR TITLE
Revert "Follow naming conventions"

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -384,12 +384,8 @@
     'name': 'storage.type.js'
   }
   {
-    'match': '(?<!\\.)\\b(async|export|extends|implements|private|protected|public|static)(?!\\s*:)\\b'
+    'match': '(?<!\\.)\\b(async|export|extends|implements|let|private|protected|public|static|var)(?!\\s*:)\\b'
     'name': 'storage.modifier.js'
-  }
-  {
-    'match': '(?<!\\.)\\b(let|var)(?!\\s*:)\\b'
-    'name': 'storage.type.var.js'
   }
   {
     'begin': '(?<!\\.)\\b(const)(?!\\s*:)\\b'

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -493,7 +493,7 @@ describe "Javascript grammar", ->
 
     it "tokenizes stored arrow functions with params", ->
       {tokens} = grammar.tokenizeLine('var func = (param1,param2)=>{}')
-      expect(tokens[0]).toEqual value: 'var', scopes: ['source.js', 'storage.type.var.js']
+      expect(tokens[0]).toEqual value: 'var', scopes: ['source.js', 'storage.modifier.js']
       expect(tokens[2]).toEqual value: 'func', scopes: ['source.js', 'meta.function.arrow.js', 'entity.name.function.js']
       expect(tokens[4]).toEqual value: '=', scopes: ['source.js', 'meta.function.arrow.js', 'keyword.operator.js']
       expect(tokens[7]).toEqual value: 'param1', scopes: ['source.js', 'meta.function.arrow.js', 'variable.parameter.function.js']

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -211,7 +211,7 @@ describe "Javascript grammar", ->
   describe "constants", ->
     it "tokenizes ALL_CAPS variables as constants", ->
       {tokens} = grammar.tokenizeLine('var MY_COOL_VAR = 42;')
-      expect(tokens[0]).toEqual value: 'var', scopes: ['source.js', 'storage.type.var.js']
+      expect(tokens[0]).toEqual value: 'var', scopes: ['source.js', 'storage.modifier.js']
       expect(tokens[1]).toEqual value: ' ', scopes: ['source.js']
       expect(tokens[2]).toEqual value: 'MY_COOL_VAR', scopes: ['source.js', 'constant.other.js']
       expect(tokens[3]).toEqual value: ' ', scopes: ['source.js']
@@ -450,7 +450,7 @@ describe "Javascript grammar", ->
 
     it "tokenizes functions", ->
       {tokens} = grammar.tokenizeLine('var func = function nonAnonymous(')
-      expect(tokens[0]).toEqual value: 'var', scopes: ['source.js', 'storage.type.var.js']
+      expect(tokens[0]).toEqual value: 'var', scopes: ['source.js', 'storage.modifier.js']
       expect(tokens[2]).toEqual value: 'func', scopes: ['source.js', 'meta.function.js', 'entity.name.function.js']
       expect(tokens[4]).toEqual value: '=', scopes: ['source.js', 'meta.function.js', 'keyword.operator.js']
       expect(tokens[6]).toEqual value: 'function', scopes: ['source.js', 'meta.function.js', 'storage.type.function.js']


### PR DESCRIPTION
Reverts atom/language-javascript#206

Atom specs will take some time to be updated.  In addition, it would be best to get the new standards written up before making any changes.  This (hopefully temporary) revert allows us to keep making other improvements to language-javascript.