### PR TITLE
Add support for properties and relax support.function regex

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -488,12 +488,12 @@
     'name': 'support.class.js'
   }
   {
-    'match': '\\b(shift|showModelessDialog|showModalDialog|showHelp|scroll|scrollX|scrollByPages|scrollByLines|scrollY|scrollTo|stop|strike|sin|sizeToContent|sidebar|signText|sort|sup|sub|substr|substring|splice|split|send|set(Milliseconds|Seconds|Minutes|Hours|Month|Year|FullYear|Date|UTC(Milliseconds|Seconds|Minutes|Hours|Month|FullYear|Date)|Time|Hotkeys|Cursor|Timeout|Interval|ZOptions|Active|Resizable|RequestHeader)|search|sqrt|slice|savePreferences|small|home|handleEvent|navigate|char|charCodeAt|charAt|cos|concat|contextual|confirm|compile|ceil|clear|clearTimeout|clearInterval|captureEvents|call|createStyleSheet|createPopup|createEventObject|to(GMTString|UTCString|String|Source|UpperCase|LowerCase|LocaleString)|test|tan|taint|taintEnabled|isNaN|isFinite|indexOf|italics|disableExternalCapture|dump|detachEvent|unshift|untaint|unescape|unwatch|updateCommands|join|javaEnabled|pop|pow|push|plugins.refresh|paddings|parse|parseInt|parseFloat|print|prompt|preference|escape|enableExternalCapture|eval|elementFromPoint|exp|exec|execScript|execCommand|valueOf|UTC|queryCommandState|queryCommandIndeterm|queryCommandEnabled|queryCommandValue|find|file|fileModifiedDate|fileSize|fileCreatedDate|fileUpdatedDate|fixed|fontsize|fontcolor|forward|floor|fromCharCode|watch|link|load|log|lastIndexOf|asin|anchor|acos|attachEvent|atob|atan|atan2|apply|alert|abs|abort|round|routeEvents|resize|resizeBy|resizeTo|recalc|returnValue|replace|reverse|reload|releaseCapture|releaseEvents|random|go|get(Milliseconds|Seconds|Minutes|Hours|Month|Day|Year|FullYear|Time|Date|TimezoneOffset|UTC(Milliseconds|Seconds|Minutes|Hours|Day|Month|FullYear|Date)|Attention|Selection|ResponseHeader|AllResponseHeaders)|min|moveBy|moveBelow|moveTo|moveToAbsolute|moveAbove|mergeAttributes|match|margins|max|btoa|big|bold|borderWidths|blink|back)\\b(?=\\()'
-    'name': 'support.function.js'
-  }
-  {
     'match': '\\b(substringData|submit|splitText|setNamedItem|setAttribute|setAttributeNode|select|hasChildNodes|hasFeature|namedItem|click|close|cloneNode|createComment|createCDATASection|createCaption|createTHead|createTextNode|createTFoot|createDocumentFragment|createProcessingInstruction|createEntityReference|createElement|createAttribute|tabIndex|insertRow|insertBefore|insertCell|insertData|item|open|deleteRow|deleteCell|deleteCaption|deleteTHead|deleteTFoot|deleteData|focus|write|writeln|add|appendChild|appendData|reset|replaceChild|replaceData|move|moveNamedItem|moveChild|moveAttribute|moveAttributeNode|getNamedItem|getElementsByName|getElementsByTagName|getElementById|getAttribute|getAttributeNode|blur)\\b(?=\\\()'
     'name': 'support.function.dom.js'
+  }
+  {
+    'match': '\\b\\w+\\b(?=\\()'
+    'name': 'support.function.js'
   }
   {
     'match': '(?<=\\.)(systemLanguage|scripts|scrollbars|screenX|screenY|screenTop|screenLeft|style|styleSheets|status|statusText|statusbar|siblingBelow|siblingAbove|source|suffixes|security|securityPolicy|selection|self|history|host|hostname|hash|hasFocus|XMLDocument|XSLDocument|next|namespaces|namespaceURI|nameProp|MIN_VALUE|MAX_VALUE|characterSet|constructor|controllers|cookieEnabled|colorDepth|components|complete|current|cpuClass|clip|clipBoardData|clientInformation|closed|classes|callee|caller|crypto|toolbar|top|textTransform|textIndent|textDecoration|textAlign|tags|SQRT1_2|SQRT2|innerHeight|innerWidth|input|ids|ignoreCase|zIndex|oscpu|onreadystatechange|onLine|outerHeight|outerWidth|opsProfile|opener|offscreenBuffering|NEGATIVE_INFINITY|display|dialogHeight|dialogTop|dialogWidth|dialogLeft|dialogArguments|directories|description|defaultStatus|defaultChecked|defaultCharset|defaultView|userProfile|userLanguage|userAgent|uniqueID|undefined|updateInterval|_content|pixelDepth|port|personalbar|pkcs11|plugins|platform|pathname|paddingRight|paddingBottom|paddingTop|paddingLeft|parent|parentWindow|parentLayer|pageX|pageXOffset|pageY|pageYOffset|protocol|prototype|product|productSub|prompter|previous|prefix|encoding|enabledPlugin|external|expando|embeds|visiblity|vendor|vendorSub|vLinkcolor|URLUnencoded|PI|POSITIVE_INFINITY|filename|fontSize|fontFamily|fontWeight|formName|frames|frameElement|fgColor|E|whiteSpace|listStyleType|lineHeight|linkColor|location|locationbar|localName|lowsrc|length|left|leftContext|lastModified|lastMatch|lastIndex|lastParen|layers|layerX|language|appMinorVersion|appName|appCodeName|appCore|appVersion|availHeight|availTop|availWidth|availLeft|all|arity|arguments|aLinkcolor|above|right|rightContext|responseXML|responeText|readyState|global|x|y|z|mimeTypes|multiline|menubar|marginRight|marginBottom|marginTop|marginLeft|LN10|LN2|LOG10E|LOG2E|bottom|border(Width|RightWidth|BottomWidth|Style|Color|TopWidth|LeftWidth)|bufferDepth|below|backgroundColor|backgroundImage)\\b'
@@ -518,6 +518,10 @@
   {
     'match': '(?<!\\.)\\b(module|exports|__filename|__dirname|global|process)(?!\\s*:)\\b'
     'name': 'support.variable.js'
+  }
+  {
+    'match': '(?<=\\.)([a-zA-Z_$][a-zA-Z_$0-9]*)\\b'
+    'name': 'entity.name.property.js'
   }
   {
     'match': '\\b(Infinity|NaN|undefined)\\b'

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -414,7 +414,6 @@ describe "Javascript grammar", ->
       expect(tokens[8]).toEqual value: 'nonAnonymous', scopes: ['source.js', 'meta.function.js', 'entity.name.function.js']
       expect(tokens[9]).toEqual value: '(', scopes: ['source.js', 'meta.function.js', 'punctuation.definition.parameters.begin.js']
 
-    it "tokenizes methods", ->
       {tokens} = grammar.tokenizeLine('f(a, b) {}')
       expect(tokens[0]).toEqual value: 'f', scopes: ['source.js', 'meta.method.js', 'entity.name.function.js']
       expect(tokens[1]).toEqual value: '(', scopes: ['source.js', 'meta.method.js', 'punctuation.definition.parameters.begin.js']
@@ -447,6 +446,17 @@ describe "Javascript grammar", ->
       expect(tokens[34]).toEqual value: ']', scopes: ['source.js', 'meta.method.js', 'meta.brace.square.js']
       expect(tokens[35]).toEqual value: '}', scopes: ['source.js', 'meta.method.js', 'meta.brace.curly.js']
       expect(tokens[36]).toEqual value: ')', scopes: ['source.js', 'meta.method.js', 'punctuation.definition.parameters.end.js']
+
+      {tokens} = grammar.tokenizeLine('hello.wow().submit();')
+      expect(tokens[0]).toEqual value: 'hello', scopes: ['source.js']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.method.period.js']
+      expect(tokens[2]).toEqual value: 'wow', scopes: ['source.js', 'support.function.js']
+      expect(tokens[3]).toEqual value: '(', scopes: ['source.js', 'meta.brace.round.js']
+      expect(tokens[4]).toEqual value: ')', scopes: ['source.js', 'meta.brace.round.js']
+      expect(tokens[5]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.method.period.js']
+      expect(tokens[6]).toEqual value: 'submit', scopes: ['source.js', 'support.function.dom.js']
+      expect(tokens[7]).toEqual value: '(', scopes: ['source.js', 'meta.brace.round.js']
+      expect(tokens[8]).toEqual value: ')', scopes: ['source.js', 'meta.brace.round.js']
 
     it "tokenizes functions", ->
       {tokens} = grammar.tokenizeLine('var func = function nonAnonymous(')
@@ -508,7 +518,7 @@ describe "Javascript grammar", ->
       expect(tokens[1]).toEqual value: "a", scopes: ['source.js', 'string.quoted.single.js']
       expect(tokens[2]).toEqual value: "'", scopes: ['source.js', 'string.quoted.single.js', 'punctuation.definition.string.end.js']
       expect(tokens[3]).toEqual value: ".", scopes: ['source.js', 'meta.delimiter.method.period.js']
-      expect(tokens[4]).toEqual value: "b", scopes: ['source.js']
+      expect(tokens[4]).toEqual value: "b", scopes: ['source.js', 'support.function.js']
       expect(tokens[5]).toEqual value: "(", scopes: ['source.js', 'meta.brace.round.js']
       expect(tokens[6]).toEqual value: "'", scopes: ['source.js', 'string.quoted.single.js', 'punctuation.definition.string.begin.js']
       expect(tokens[7]).toEqual value: ":c(d)", scopes: ['source.js', 'string.quoted.single.js']
@@ -542,6 +552,23 @@ describe "Javascript grammar", ->
         expect(tokens[13]).toEqual value: ':function()', scopes: ['source.js', scope]
         expect(tokens[14]).toEqual value: delim, scopes: ['source.js', scope, 'punctuation.definition.string.end.js']
         expect(tokens[15]).toEqual value: ')', scopes: ['source.js', 'meta.brace.round.js']
+
+  describe "properties", ->
+    it "tokenizes them", ->
+      {tokens} = grammar.tokenizeLine('hello.prop.anotherProp.notAProp().yesProp.window;')
+      expect(tokens[0]).toEqual value: 'hello', scopes: ['source.js']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.method.period.js']
+      expect(tokens[2]).toEqual value: 'prop', scopes: ['source.js', 'entity.name.property.js']
+      expect(tokens[3]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.method.period.js']
+      expect(tokens[4]).toEqual value: 'anotherProp', scopes: ['source.js', 'entity.name.property.js']
+      expect(tokens[5]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.method.period.js']
+      expect(tokens[6]).toEqual value: 'notAProp', scopes: ['source.js', 'support.function.js']
+      expect(tokens[7]).toEqual value: '(', scopes: ['source.js', 'meta.brace.round.js']
+      expect(tokens[8]).toEqual value: ')', scopes: ['source.js', 'meta.brace.round.js']
+      expect(tokens[9]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.method.period.js']
+      expect(tokens[10]).toEqual value: 'yesProp', scopes: ['source.js', 'entity.name.property.js']
+      expect(tokens[9]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.method.period.js']
+      expect(tokens[12]).toEqual value: 'window', scopes: ['source.js', 'support.class.js']
 
   describe "comments", ->
     it "tokenizes /* */ comments", ->


### PR DESCRIPTION
:rotating_light: :warning: Do not merge yet!  Specs on atom/atom also need to be updated! :warning: :rotating_light:

This PR replaces #210, brings back #158, and combines it with #146.

* `support.function.dom.js` has been kept and is prioritized over the now-generalized `support.function.js` regex.
* `entity.name.property.js` now catches anything that doesn't fall into `support.constant{.dom}.js` and `support.class.js`

Before:
![before](https://cloud.githubusercontent.com/assets/2766036/9526521/c00bc09c-4cb7-11e5-8170-d7b91da34e0d.png)

After:
![after](https://cloud.githubusercontent.com/assets/2766036/9526448/5e497188-4cb7-11e5-8bce-1c1be076946f.png)

/cc @bucaran since I know you had some concerns about this
/cc @nevir because this only adds `.property` for things not already marked as `.class` and `.constant`
/cc @Victorystick, @AMalininHere, @pchaigno

Refs #137
Fixes #37
Closes #146