### PR TITLE
Stop tokenizing $0 and $00 as replacement variables.

### DIFF
--- a/grammars/regular expression replacement (javascript).cson
+++ b/grammars/regular expression replacement (javascript).cson
@@ -10,7 +10,7 @@
   'regexp-replacement':
     'patterns': [
       {
-        'match': '\\$[0-9]{1,2}|\\$[&`\']'
+        'match': '\\$([1-9][0-9]|[1-9]|0[1-9]|[&`\'])'
         'name': 'variable.regexp.replacement'
       }
       {

--- a/spec/regular-expression-replacement-spec.coffee
+++ b/spec/regular-expression-replacement-spec.coffee
@@ -36,9 +36,25 @@ describe "Regular Expression Replacement grammar", ->
       expect(tokens[1]).toEqual value: '1', scopes: ['source.js.regexp.replacement']
 
   describe "Numeric placeholders", ->
+    it "doesn't tokenize $0 as a variable", ->
+      {tokens} = grammar.tokenizeLine('$0')
+      expect(tokens[0]).toEqual value: '$0', scopes: ['source.js.regexp.replacement']
+
+    it "doesn't tokenize $00 as a variable", ->
+      {tokens} = grammar.tokenizeLine('$00')
+      expect(tokens[0]).toEqual value: '$00', scopes: ['source.js.regexp.replacement']
+
     it "tokenizes $1 as a variable", ->
       {tokens} = grammar.tokenizeLine('$1')
       expect(tokens[0]).toEqual value: '$1', scopes: ['source.js.regexp.replacement', 'variable.regexp.replacement']
+
+    it "tokenizes $01 as a variable", ->
+      {tokens} = grammar.tokenizeLine('$01')
+      expect(tokens[0]).toEqual value: '$01', scopes: ['source.js.regexp.replacement', 'variable.regexp.replacement']
+
+    it "tokenizes $3 as a variable", ->
+      {tokens} = grammar.tokenizeLine('$3')
+      expect(tokens[0]).toEqual value: '$3', scopes: ['source.js.regexp.replacement', 'variable.regexp.replacement']
 
     it "tokenizes $10 as a variable", ->
       {tokens} = grammar.tokenizeLine('$10')


### PR DESCRIPTION
At least in Firefox, Chrome, and the Atom Find-and-Replace, $0 and $00 are
treated as plain string values while $& is used as the variable to hold the
full match.

This commit updates the replacement grammar to only allow integers 1-99,
with and without a leading 0.

Here is the new behavior in Atom Find-and-Replace:
![screen shot 2015-09-01 at 10 58 16 am](https://cloud.githubusercontent.com/assets/25242/9607694/93b837fc-5098-11e5-87be-69b4be752dba.png)
