### PR TITLE
Allow regexp to immediately follow `?` ternary operator

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -553,7 +553,7 @@
     'name': 'constant.language.js'
   }
   {
-    'begin': '(?<=[\\[=(:+,!]|^|return|&&|\\|\\|)\\s*(/)(?![/*+{}?])(?=.*/)'
+    'begin': '(?<=[\\[=(?:+,!]|^|return|&&|\\|\\|)\\s*(/)(?![/*+{}?])(?=.*/)'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.string.begin.js'

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -111,6 +111,21 @@ describe "Javascript grammar", ->
       expect(tokens[6]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.end.js']
       expect(tokens[7]).toEqual value: ']', scopes: ['source.js', 'meta.brace.square.js']
 
+    it "tokenizes regular expressions inside ternary expressions", ->
+      {tokens} = grammar.tokenizeLine('a ? /b/ : /c/')
+      expect(tokens[ 0]).toEqual value: 'a ', scopes: ['source.js']
+      expect(tokens[ 1]).toEqual value: '?', scopes: ['source.js', 'keyword.operator.js']
+      expect(tokens[ 2]).toEqual value: ' ', scopes: ['source.js', 'string.regexp.js']
+      expect(tokens[ 3]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.begin.js']
+      expect(tokens[ 4]).toEqual value: 'b', scopes: ['source.js', 'string.regexp.js']
+      expect(tokens[ 5]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.end.js']
+      expect(tokens[ 6]).toEqual value: ' ', scopes: ['source.js']
+      expect(tokens[ 7]).toEqual value: ':', scopes: ['source.js', 'keyword.operator.js']
+      expect(tokens[ 8]).toEqual value: ' ', scopes: ['source.js', 'string.regexp.js']
+      expect(tokens[ 9]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.begin.js']
+      expect(tokens[10]).toEqual value: 'c', scopes: ['source.js', 'string.regexp.js']
+      expect(tokens[11]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.end.js']
+
     it "verifies that regular expressions have explicit count modifiers", ->
       source = fs.readFileSync(path.resolve(__dirname, '..', 'grammars', 'javascript.cson'), 'utf8')
       expect(source.search /{,/).toEqual -1


### PR DESCRIPTION
In the expression `a ? /b/ : /c/`, the first regexp wasn't recognized as such, but was tokenized as a sequence of operators instead. This fixes it by allowing regexp to immediately follow the `?` operator.

This fixes the syntax highlighting issue in Atom as well as on GitHub.com that manifests itself like this:

<img width="920" alt="screen shot 2015-09-21 at 5 48 52 pm" src="https://cloud.githubusercontent.com/assets/887/9996844/6206fa62-6089-11e5-904e-6cb37cf40db4.png">

This is related to #93 