### PR TITLE
Fix tokenizing of various keywords within ternary expression

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -468,11 +468,15 @@
     ]
   }
   {
-    'match': '(?<!\\.)\\b(yield)(?!\\s*:)\\b(?:\\s*(\\*))?',
+    'match': '(?<!\\.)\\b(yield)(?!\\s*:)\\b(?:\\s*(\\*))?|(?<=\\?)(?:\\s*)(yield)(?=\\s*:)',
     'captures':
       '1':
         'name': 'keyword.control.js'
       '2':
+        'name': 'storage.modifier.js'
+      '3':
+        'name': 'keyword.control.js'
+      '4':
         'name': 'storage.modifier.js'
     'name': 'meta.control.yield.js'
   }
@@ -489,28 +493,44 @@
     'name': 'keyword.operator.js'
   }
   {
-    'match': '(?<!\\.)\\btrue(?!\\s*:)\\b'
-    'name': 'constant.language.boolean.true.js'
+    'match': '(?<!\\.)\\b(true|false)(?!\\s*:)\\b|(?<=\\?)(?:\\s*)(true|false)(?=\\s*:)'
+    'captures':
+      '1':
+        'name': 'constant.language.boolean.$1.js'
+      '2':
+        'name': 'constant.language.boolean.$2.js'
   }
   {
-    'match': '(?<!\\.)\\bfalse(?!\\s*:)\\b'
-    'name': 'constant.language.boolean.false.js'
+    'match': '(?<!\\.)\\b(null)(?!\\s*:)\\b|(?<=\\?)(?:\\s*)(null)(?=\\s*:)'
+    'captures':
+      '1':
+        'name': 'constant.language.null.js'
+      '2':
+        'name': 'constant.language.null.js'
   }
   {
-    'match': '(?<!\\.)\\bnull(?!\\s*:)\\b'
-    'name': 'constant.language.null.js'
+    'match': '(?<!\\.)\\b([A-Z][A-Z0-9_]+)(?!\\s*:)\\b|(?<=\\?)(?:\\s*)([A-Z][A-Z0-9_]+)(?=\\s*:)'
+    'captures':
+      '1':
+        'name': 'constant.other.js'
+      '2':
+        'name': 'constant.other.js'
   }
   {
-    'match': '(?<!\\.)\\b([A-Z][A-Z0-9_]+)(?!\\s*:)\\b'
-    'name': 'constant.other.js'
+    'match': '(?<!\\.)\\b(super|this)(?!\\s*:)\\b|(?<=\\?)(?:\\s*)(super|this)(?=\\s*:)'
+    'captures':
+      '1':
+        'name': 'variable.language.js'
+      '2':
+        'name': 'variable.language.js'
   }
   {
-    'match': '(?<!\\.)\\b(super|this)(?!\\s*:)\\b'
-    'name': 'variable.language.js'
-  }
-  {
-    'match': '(?<!\\.)\\b(debugger)(?!\\s*:)\\b'
-    'name': 'keyword.other.js'
+    'match': '(?<!\\.)\\b(debugger)(?!\\s*:)\\b|(?<=\\?)(?:\\s*)(debugger)(?=\\s*:)'
+    'captures':
+      '1':
+        'name': 'keyword.other.js'
+      '2':
+        'name': 'keyword.other.js'
   }
   {
     'match': '(?<!\\$)\\b(Anchor|Applet|Area|Array|Boolean|Button|Checkbox|Date|document|event|FileUpload|Form|Frame|Function|Hidden|History|Image|JavaArray|JavaClass|JavaObject|JavaPackage|java|Layer|Link|Location|Math|MimeType|Number|navigator|netscape|Object|Option|Packages|Password|Plugin|Radio|RegExp|Reset|Select|String|Style|Submit|screen|sun|Text|Textarea|window|XMLHttpRequest)\\b'
@@ -545,8 +565,12 @@
     'name': 'support.function.js'
   }
   {
-    'match': '(?<!\\.)\\b(module|exports|__filename|__dirname|global|process)(?!\\s*:)\\b'
-    'name': 'support.variable.js'
+    'match': '(?<!\\.)\\b(module|exports|__filename|__dirname|global|process)(?!\\s*:)\\b|(?<=\\?)(?:\\s*)(module|exports|__filename|__dirname|global|process)(?=\\s*:)'
+    'captures':
+      '1':
+        'name': 'support.variable.js'
+      '2':
+        'name': 'support.variable.js'
   }
   {
     'match': '\\b(Infinity|NaN|undefined)\\b'

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -70,10 +70,15 @@ describe "Javascript grammar", ->
           expect(tokens[0]).toEqual value: keyword, scopes: ['source.js']
           expect(tokens[1]).toEqual value: ':', scopes: ['source.js', 'keyword.operator.js']
 
-        it "tokenizes `#{keyword}` in ternary expressions", ->
+        it "tokenizes `#{keyword}` in the middle of ternary expressions", ->
           {tokens} = grammar.tokenizeLine("a ? #{keyword} : b")
           expect(tokens[2]).toEqual value: ' ', scopes: ['source.js']
           expect(tokens[3]).toEqual value: keyword, scopes: ['source.js', scope]
+
+        it "tokenizes `#{keyword}` at the end of ternary expressions", ->
+          {tokens} = grammar.tokenizeLine("a ? b : #{keyword}")
+          expect(tokens[4]).toEqual value: ' ', scopes: ['source.js']
+          expect(tokens[5]).toEqual value: keyword, scopes: ['source.js', scope]
 
   describe "built-in globals", ->
     it "tokenizes them as support classes", ->
@@ -363,9 +368,13 @@ describe "Javascript grammar", ->
       expect(tokens[0]).toEqual value: 'FOO', scopes: ['source.js']
       expect(tokens[1]).toEqual value: ':', scopes: ['source.js', 'keyword.operator.js']
 
-    it "tokenizes constants in ternary expressions", ->
+    it "tokenizes constants in the middle of ternary expressions", ->
       {tokens} = grammar.tokenizeLine('a ? FOO : b')
       expect(tokens[3]).toEqual value: 'FOO', scopes: ['source.js', 'constant.other.js']
+
+    it "tokenizes constants at the end of ternary expressions", ->
+      {tokens} = grammar.tokenizeLine('a ? b : FOO')
+      expect(tokens[5]).toEqual value: 'FOO', scopes: ['source.js', 'constant.other.js']
 
   describe "ES6 string templates", ->
     it "tokenizes them as strings", ->
@@ -435,9 +444,13 @@ describe "Javascript grammar", ->
       expect(tokens[0]).toEqual value: 'yield', scopes: ['source.js']
       expect(tokens[1]).toEqual value: ':', scopes: ['source.js', 'keyword.operator.js']
 
-    it "tokenizes yield in ternary expressions", ->
+    it "tokenizes yield in the middle of ternary expressions", ->
       {tokens} = grammar.tokenizeLine('a ? yield : b')
       expect(tokens[3]).toEqual value: 'yield', scopes: ['source.js', 'meta.control.yield.js', 'keyword.control.js']
+
+    it "tokenizes yield at the end of ternary expressions", ->
+      {tokens} = grammar.tokenizeLine('a ? b : yield')
+      expect(tokens[5]).toEqual value: 'yield', scopes: ['source.js', 'meta.control.yield.js', 'keyword.control.js']
 
   describe "default: in a switch statement", ->
     it "tokenizes it as a keyword", ->


### PR DESCRIPTION
Supports proper tokenizing of these keywords when they appear as subexpression `b` within ternary expression `a ? b : c`:

    yield, true, false, null, [CONSTANT], super, this, debugger,
    module, exports, __filename, __dirname, global, process

They are not tokenized because there was a rule that these keywords should not be followed by `:`. This was to compensate for JS key/value syntax `{ foo: bar }`.

The fix adds an alternate pattern for each of these keywords that explicitly allows these keywords to be followed by `:` if they were preceded by `?`.

Fixes #93