### PR TITLE
ES6 import export

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -116,6 +116,137 @@
     'name': 'meta.import.js'
   }
   {
+    'comment': 'ES6 export'
+    'begin': '(?<!\\.)\\b(export)(?!\\s*:)\\b'
+    'beginCaptures':
+      '1':
+        'name': 'keyword.control.js'
+    'patterns': [
+      {
+        'include': '#numbers'
+      }
+      {
+        'comment': '`{ member1 , member2 as alias2 , [...] }` inside re-export'
+        'begin': '\\{(?=.*\\bfrom\\b)'
+        'beginCaptures':
+          0:
+            'name': 'punctuation.definition.modules.begin.js'
+        'end': '\\}'
+        'endCaptures':
+          0:
+            'name': 'punctuation.definition.modules.end.js'
+        'patterns': [
+          {
+            'comment': '(default|name) as alias'
+            'captures':
+              '1':
+                'name': 'variable.language.default.js'
+              '2':
+                'name': 'variable.other.module.js'
+              '3':
+                'name': 'keyword.control.js'
+              '4':
+                'name': 'variable.language.default.js'
+              '5':
+                'name': 'invalid.illegal.js'
+              '6':
+                'name': 'variable.other.module-alias.js'
+            'match': '(?x)
+              (?: \\b(default)\\b | \\b([a-zA-Z_$][a-zA-Z_$0-9]*)\\b)
+              \\s*
+              (\\b as \\b)
+              \\s*
+              (?: \\b(default)\\b | (\\*) | \\b([a-zA-Z_$][a-zA-Z_$0-9]*)\\b)
+            '
+          }
+          {
+            'match': ','
+            'name': 'meta.delimiter.object.comma.js'
+          }
+          {
+            'match': '\\b([a-zA-Z_$][a-zA-Z_$0-9]*)\\b'
+            'name': 'variable.other.module.js'
+          }
+        ]
+      }
+      {
+        'comment': '{ member1 , member2 as alias2 , [...] }'
+        'begin': '(?![a-zA-Z_$0-9])\\{'
+        'beginCaptures':
+          0:
+            'name': 'punctuation.definition.modules.begin.js'
+        'end': '\\}'
+        'endCaptures':
+          0:
+            'name': 'punctuation.definition.modules.end.js'
+        'patterns': [
+          {
+            'comment': 'name as (default|alias)'
+            'captures':
+              '1':
+                'name': 'invalid.illegal.js'
+              '2':
+                'name': 'variable.other.module.js'
+              '3':
+                'name': 'keyword.control.js'
+              '4':
+                'name': 'variable.language.default.js'
+              '5':
+                'name': 'invalid.illegal.js'
+              '6':
+                'name': 'variable.other.module-alias.js'
+            'match': '(?x)
+              (?: \\b(default)\\b | \\b([a-zA-Z_$][a-zA-Z_$0-9]*)\\b)
+              \\s*
+              (\\b as \\b)
+              \\s*
+              (?: \\b(default)\\b | (\\*) | \\b([a-zA-Z_$][a-zA-Z_$0-9]*)\\b)
+            '
+          }
+          {
+            'match': ','
+            'name': 'meta.delimiter.object.comma.js'
+          }
+          {
+            'match': '\\b([a-zA-Z_$][a-zA-Z_$0-9]*)\\b'
+            'name': 'variable.other.module.js'
+          }
+        ]
+      }
+      {
+        'match': '\\*(?=.*\\bfrom\\b)'
+        'name': 'variable.language.import-all.js'
+      }
+      {
+        'match': '\\b(default)\\b'
+        'name': 'variable.language.default.js'
+      }
+      {
+        'include': '#strings'
+      }
+      {
+        'include': '#comments'
+      }
+      {
+        'match': '\\b(from)\\b'
+        'name': 'keyword.control.js'
+      }
+      {
+        'match': '\\b([a-zA-Z_$][a-zA-Z_$0-9]*)\\b'
+        'name': 'variable.other.module.js'
+      }
+      {
+        'match': ','
+        'name': 'meta.delimiter.object.comma.js'
+      }
+      {
+        'include': '#operators'
+      }
+    ]
+    'end': '(?=;|\\bfunction\\b|\\bclass\\b|\\blet\\b|\\bvar\\b|\\bconst\\b|$)'
+    'name': 'meta.export.js'
+  }
+  {
     'captures':
       '1':
         'name': 'support.class.js'
@@ -661,9 +792,7 @@
     ]
   }
   {
-    'match': '!=|!==|<=|>=|<<=|>>=|>>>=|\\*=|(?<!\\()/=|%=|\\+=|\\-=|&=|\\^=|!|%|&|\\*|/|\\-\\-|\\-|\\+\\+|\\+|~|===|==|=|<>|<|>|!|&&|\\|\\||\\?|\\:|\\^'
-    'comment': 'match 2-character operator first'
-    'name': 'keyword.operator.js'
+    'include': '#operators'
   }
   {
     'match': '\\;'
@@ -709,6 +838,14 @@
       {
         'match': '\\b((0(x|X)[0-9a-fA-F]+)|(0(b|B)[01]+)|(0(o|O)[0-7]+)|([0-9]+(\\.[0-9]+)?)((e|E)[+-]?[0-9]+)?)\\b'
         'name': 'constant.numeric.js'
+      }
+    ]
+  'operators':
+    'patterns': [
+      {
+        'match': '!=|!==|<=|>=|<<=|>>=|>>>=|\\*=|(?<!\\()/=|%=|\\+=|\\-=|&=|\\^=|!|%|&|\\*|/|\\-\\-|\\-|\\+\\+|\\+|~|===|==|=|<>|<|>|!|&&|\\|\\||\\?|\\:|\\^'
+        'comment': 'match 2-character operator first'
+        'name': 'keyword.operator.js'
       }
     ]
   'strings':

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -14,11 +14,85 @@
 'name': 'JavaScript'
 'patterns': [
   {
+    'comment': 'ES6 import'
     'begin': '(?<!\\.)\\b(import)(?!\\s*:)\\b'
     'beginCaptures':
       '1':
         'name': 'keyword.control.js'
     'patterns': [
+      {
+        'comment': '{ member1 , member2 as alias2 , [...] }'
+        'begin': '\\{'
+        'beginCaptures':
+          0:
+            'name': 'punctuation.definition.modules.begin.js'
+        'end': '\\}'
+        'endCaptures':
+          0:
+            'name': 'punctuation.definition.modules.end.js'
+        'patterns': [
+          {
+            'comment': '(default|name) as alias'
+            'captures':
+              '1':
+                'name': 'variable.language.default.js'
+              '2':
+                'name': 'variable.other.module.js'
+              '3':
+                'name': 'keyword.control.js'
+              '4':
+                'name': 'invalid.illegal.js'
+              '5':
+                'name': 'variable.other.module-alias.js'
+            'match': '(?x)
+              (?: \\b(default)\\b | \\b([a-zA-Z_$][a-zA-Z_$0-9]*)\\b)
+              \\s*
+              (\\b as \\b)
+              \\s*
+              (?: (\\b default \\b | \\*) | \\b([a-zA-Z_$][a-zA-Z_$0-9]*)\\b)
+            '
+          }
+          {
+            'match': ','
+            'name': 'meta.delimiter.object.comma.js'
+          }
+          {
+            'match': '\\b([a-zA-Z_$][a-zA-Z_$0-9]*)\\b'
+            'name': 'variable.other.module.js'
+          }
+        ]
+      }
+      {
+        'comment': '(default|*|name) as alias'
+        'captures':
+          '1':
+            'name': 'variable.language.default.js'
+          '2':
+            'name': 'variable.language.import-all.js'
+          '3':
+            'name': 'variable.other.module.js'
+          '4':
+            'name': 'keyword.control.js'
+          '5':
+            'name': 'invalid.illegal.js'
+          '6':
+            'name': 'variable.other.module-alias.js'
+        'match': '(?x)
+          (?: \\b(default)\\b | (\\*) | \\b([a-zA-Z_$][a-zA-Z_$0-9]*)\\b)
+          \\s*
+          (\\b as \\b)
+          \\s*
+          (?: (\\b default \\b | \\*) | \\b([a-zA-Z_$][a-zA-Z_$0-9]*)\\b)
+        '
+      }
+      {
+        'match': '\\*'
+        'name': 'variable.language.import-all.js'
+      }
+      {
+        'match': '\\b(default)\\b'
+        'name': 'variable.language.default.js'
+      }
       {
         'include': '#strings'
       }
@@ -26,19 +100,16 @@
         'include': '#comments'
       }
       {
-        'match': '\\b(as|from)\\b',
+        'match': '\\b(from)\\b'
         'name': 'keyword.control.js'
       }
       {
-        'match': '\\b([a-zA-Z_$][a-zA-Z_$0-9]*)\\b'
+        'match': '\\b([a-zA-Z_$][a-zA-Z_$0-9]*)\\b(?=.*\\bfrom\\b)'
+        'name': 'variable.other.module.js'
       }
       {
         'match': ','
         'name': 'meta.delimiter.object.comma.js'
-      }
-      {
-        'match': '\\{|\\}'
-        'name': 'meta.brace.curly.js'
       }
     ]
     'end': '(?=;|$)'

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -434,69 +434,73 @@ describe "Javascript grammar", ->
     it "tokenizes import", ->
       {tokens} = grammar.tokenizeLine('import "module-name";')
       expect(tokens[0]).toEqual value: 'import', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
+      expect(tokens[2]).toEqual value: '"', scopes: ['source.js', 'meta.import.js', 'string.quoted.double.js', 'punctuation.definition.string.begin.js']
+      expect(tokens[3]).toEqual value: 'module-name', scopes: ['source.js', 'meta.import.js', 'string.quoted.double.js']
+      expect(tokens[4]).toEqual value: '"', scopes: ['source.js', 'meta.import.js', 'string.quoted.double.js', 'punctuation.definition.string.end.js']
+      expect(tokens[5]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
 
     it "tokenizes default import", ->
       {tokens} = grammar.tokenizeLine('import defaultMember from "module-name";')
       expect(tokens[0]).toEqual value: 'import', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
-      expect(tokens[2]).toEqual value: 'defaultMember', scopes: ['source.js', 'meta.import.js']
+      expect(tokens[2]).toEqual value: 'defaultMember', scopes: ['source.js', 'meta.import.js', 'variable.other.module.js']
       expect(tokens[4]).toEqual value: 'from', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
 
     it "tokenizes default named import", ->
       {tokens} = grammar.tokenizeLine('import { default as defaultMember } from "module-name";')
       expect(tokens[0]).toEqual value: 'import', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
-      expect(tokens[2]).toEqual value: '{', scopes: ['source.js', 'meta.import.js', 'meta.brace.curly.js']
-      expect(tokens[4]).toEqual value: 'default', scopes: ['source.js', 'meta.import.js']
+      expect(tokens[2]).toEqual value: '{', scopes: ['source.js', 'meta.import.js', 'punctuation.definition.modules.begin.js']
+      expect(tokens[4]).toEqual value: 'default', scopes: ['source.js', 'meta.import.js', 'variable.language.default.js']
       expect(tokens[6]).toEqual value: 'as', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
-      expect(tokens[8]).toEqual value: 'defaultMember', scopes: ['source.js', 'meta.import.js']
-      expect(tokens[10]).toEqual value: '}', scopes: ['source.js', 'meta.import.js', 'meta.brace.curly.js']
+      expect(tokens[8]).toEqual value: 'defaultMember', scopes: ['source.js', 'meta.import.js', 'variable.other.module-alias.js']
+      expect(tokens[10]).toEqual value: '}', scopes: ['source.js', 'meta.import.js', 'punctuation.definition.modules.end.js']
       expect(tokens[12]).toEqual value: 'from', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
 
     it "tokenizes named import", ->
       {tokens} = grammar.tokenizeLine('import { member } from "module-name";')
       expect(tokens[0]).toEqual value: 'import', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
-      expect(tokens[2]).toEqual value: '{', scopes: ['source.js', 'meta.import.js', 'meta.brace.curly.js']
-      expect(tokens[4]).toEqual value: 'member', scopes: ['source.js', 'meta.import.js']
-      expect(tokens[6]).toEqual value: '}', scopes: ['source.js', 'meta.import.js', 'meta.brace.curly.js']
+      expect(tokens[2]).toEqual value: '{', scopes: ['source.js', 'meta.import.js', 'punctuation.definition.modules.begin.js']
+      expect(tokens[4]).toEqual value: 'member', scopes: ['source.js', 'meta.import.js', 'variable.other.module.js']
+      expect(tokens[6]).toEqual value: '}', scopes: ['source.js', 'meta.import.js', 'punctuation.definition.modules.end.js']
       expect(tokens[8]).toEqual value: 'from', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
 
       {tokens} = grammar.tokenizeLine('import { member1 , member2 as alias2 } from "module-name";')
       expect(tokens[0]).toEqual value: 'import', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
-      expect(tokens[2]).toEqual value: '{', scopes: ['source.js', 'meta.import.js', 'meta.brace.curly.js']
-      expect(tokens[4]).toEqual value: 'member1', scopes: ['source.js', 'meta.import.js']
+      expect(tokens[2]).toEqual value: '{', scopes: ['source.js', 'meta.import.js', 'punctuation.definition.modules.begin.js']
+      expect(tokens[4]).toEqual value: 'member1', scopes: ['source.js', 'meta.import.js', 'variable.other.module.js']
       expect(tokens[6]).toEqual value: ',', scopes: ['source.js', 'meta.import.js', 'meta.delimiter.object.comma.js']
-      expect(tokens[8]).toEqual value: 'member2', scopes: ['source.js', 'meta.import.js']
+      expect(tokens[8]).toEqual value: 'member2', scopes: ['source.js', 'meta.import.js', 'variable.other.module.js']
       expect(tokens[10]).toEqual value: 'as', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
-      expect(tokens[12]).toEqual value: 'alias2', scopes: ['source.js', 'meta.import.js']
-      expect(tokens[14]).toEqual value: '}', scopes: ['source.js', 'meta.import.js', 'meta.brace.curly.js']
+      expect(tokens[12]).toEqual value: 'alias2', scopes: ['source.js', 'meta.import.js', 'variable.other.module-alias.js']
+      expect(tokens[14]).toEqual value: '}', scopes: ['source.js', 'meta.import.js', 'punctuation.definition.modules.end.js']
       expect(tokens[16]).toEqual value: 'from', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
 
     it "tokenizes entire module import", ->
       {tokens} = grammar.tokenizeLine('import * as name from "module-name";')
       expect(tokens[0]).toEqual value: 'import', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
-      expect(tokens[1]).toEqual value: ' * ', scopes: ['source.js', 'meta.import.js']
-      expect(tokens[2]).toEqual value: 'as', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
-      expect(tokens[4]).toEqual value: 'name', scopes: ['source.js', 'meta.import.js']
-      expect(tokens[6]).toEqual value: 'from', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
+      expect(tokens[2]).toEqual value: '*', scopes: ['source.js', 'meta.import.js', 'variable.language.import-all.js']
+      expect(tokens[4]).toEqual value: 'as', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
+      expect(tokens[6]).toEqual value: 'name', scopes: ['source.js', 'meta.import.js', 'variable.other.module-alias.js']
+      expect(tokens[8]).toEqual value: 'from', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
 
     it "tokenizes `import defaultMember, { member } from 'module-name';`", ->
       {tokens} = grammar.tokenizeLine('import defaultMember, { member } from "module-name";')
       expect(tokens[0]).toEqual value: 'import', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
-      expect(tokens[2]).toEqual value: 'defaultMember', scopes: ['source.js', 'meta.import.js']
+      expect(tokens[2]).toEqual value: 'defaultMember', scopes: ['source.js', 'meta.import.js', 'variable.other.module.js']
       expect(tokens[3]).toEqual value: ',', scopes: ['source.js', 'meta.import.js', 'meta.delimiter.object.comma.js']
-      expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'meta.import.js', 'meta.brace.curly.js']
-      expect(tokens[7]).toEqual value: 'member', scopes: ['source.js', 'meta.import.js']
-      expect(tokens[9]).toEqual value: '}', scopes: ['source.js', 'meta.import.js', 'meta.brace.curly.js']
+      expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'meta.import.js', 'punctuation.definition.modules.begin.js']
+      expect(tokens[7]).toEqual value: 'member', scopes: ['source.js', 'meta.import.js', 'variable.other.module.js']
+      expect(tokens[9]).toEqual value: '}', scopes: ['source.js', 'meta.import.js', 'punctuation.definition.modules.end.js']
       expect(tokens[11]).toEqual value: 'from', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
 
     it "tokenizes `import defaultMember, * as alias from 'module-name';", ->
       {tokens} = grammar.tokenizeLine('import defaultMember, * as alias from "module-name";')
       expect(tokens[0]).toEqual value: 'import', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
-      expect(tokens[2]).toEqual value: 'defaultMember', scopes: ['source.js', 'meta.import.js']
+      expect(tokens[2]).toEqual value: 'defaultMember', scopes: ['source.js', 'meta.import.js', 'variable.other.module.js']
       expect(tokens[3]).toEqual value: ',', scopes: ['source.js', 'meta.import.js', 'meta.delimiter.object.comma.js']
-      expect(tokens[4]).toEqual value: ' * ', scopes: ['source.js', 'meta.import.js']
-      expect(tokens[5]).toEqual value: 'as', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
-      expect(tokens[7]).toEqual value: 'alias', scopes: ['source.js', 'meta.import.js']
-      expect(tokens[9]).toEqual value: 'from', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
+      expect(tokens[5]).toEqual value: '*', scopes: ['source.js', 'meta.import.js', 'variable.language.import-all.js']
+      expect(tokens[7]).toEqual value: 'as', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
+      expect(tokens[9]).toEqual value: 'alias', scopes: ['source.js', 'meta.import.js', 'variable.other.module-alias.js']
+      expect(tokens[11]).toEqual value: 'from', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
 
   describe "ES6 export", ->
     it "tokenizes named export", ->
@@ -817,12 +821,9 @@ describe "Javascript grammar", ->
       expect(tokens[4]).toEqual value: '*/', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.definition.comment.js']
 
     it "tokenizes // comments", ->
-      {tokens} = grammar.tokenizeLine('import point; // comment')
-      expect(tokens[0]).toEqual value: 'import', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
-      expect(tokens[2]).toEqual value: 'point', scopes: ['source.js', 'meta.import.js']
-      expect(tokens[3]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
-      expect(tokens[5]).toEqual value: '//', scopes: ['source.js', 'comment.line.double-slash.js', 'punctuation.definition.comment.js']
-      expect(tokens[6]).toEqual value: ' comment', scopes: ['source.js', 'comment.line.double-slash.js']
+      {tokens} = grammar.tokenizeLine('// comment')
+      expect(tokens[0]).toEqual value: '//', scopes: ['source.js', 'comment.line.double-slash.js', 'punctuation.definition.comment.js']
+      expect(tokens[1]).toEqual value: ' comment', scopes: ['source.js', 'comment.line.double-slash.js']
 
     it "tokenizes comments inside constant definitions", ->
       {tokens} = grammar.tokenizeLine('const a, // comment')

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -431,18 +431,72 @@ describe "Javascript grammar", ->
       expect(tokens[6]).toEqual value: ')', scopes: ['source.js', 'punctuation.definition.parameters.end.js']
 
   describe "ES6 import", ->
-    it "tokenizes import ... as", ->
-      {tokens} = grammar.tokenizeLine('import \'react\' as React')
+    it "tokenizes import", ->
+      {tokens} = grammar.tokenizeLine('import "module-name";')
       expect(tokens[0]).toEqual value: 'import', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
-      expect(tokens[6]).toEqual value: 'as', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
 
-    it "tokenizes import ... from", ->
-      {tokens} = grammar.tokenizeLine('import React from \'react\'')
+    it "tokenizes default import", ->
+      {tokens} = grammar.tokenizeLine('import defaultMember from "module-name";')
       expect(tokens[0]).toEqual value: 'import', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
+      expect(tokens[2]).toEqual value: 'defaultMember', scopes: ['source.js', 'meta.import.js']
       expect(tokens[4]).toEqual value: 'from', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
-      {tokens} = grammar.tokenizeLine('import {React} from \'react\'')
+
+    it "tokenizes default named import", ->
+      {tokens} = grammar.tokenizeLine('import { default as defaultMember } from "module-name";')
       expect(tokens[0]).toEqual value: 'import', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
+      expect(tokens[2]).toEqual value: '{', scopes: ['source.js', 'meta.import.js', 'meta.brace.curly.js']
+      expect(tokens[4]).toEqual value: 'default', scopes: ['source.js', 'meta.import.js']
+      expect(tokens[6]).toEqual value: 'as', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
+      expect(tokens[8]).toEqual value: 'defaultMember', scopes: ['source.js', 'meta.import.js']
+      expect(tokens[10]).toEqual value: '}', scopes: ['source.js', 'meta.import.js', 'meta.brace.curly.js']
+      expect(tokens[12]).toEqual value: 'from', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
+
+    it "tokenizes named import", ->
+      {tokens} = grammar.tokenizeLine('import { member } from "module-name";')
+      expect(tokens[0]).toEqual value: 'import', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
+      expect(tokens[2]).toEqual value: '{', scopes: ['source.js', 'meta.import.js', 'meta.brace.curly.js']
+      expect(tokens[4]).toEqual value: 'member', scopes: ['source.js', 'meta.import.js']
+      expect(tokens[6]).toEqual value: '}', scopes: ['source.js', 'meta.import.js', 'meta.brace.curly.js']
+      expect(tokens[8]).toEqual value: 'from', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
+
+      {tokens} = grammar.tokenizeLine('import { member1 , member2 as alias2 } from "module-name";')
+      expect(tokens[0]).toEqual value: 'import', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
+      expect(tokens[2]).toEqual value: '{', scopes: ['source.js', 'meta.import.js', 'meta.brace.curly.js']
+      expect(tokens[4]).toEqual value: 'member1', scopes: ['source.js', 'meta.import.js']
+      expect(tokens[6]).toEqual value: ',', scopes: ['source.js', 'meta.import.js', 'meta.delimiter.object.comma.js']
+      expect(tokens[8]).toEqual value: 'member2', scopes: ['source.js', 'meta.import.js']
+      expect(tokens[10]).toEqual value: 'as', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
+      expect(tokens[12]).toEqual value: 'alias2', scopes: ['source.js', 'meta.import.js']
+      expect(tokens[14]).toEqual value: '}', scopes: ['source.js', 'meta.import.js', 'meta.brace.curly.js']
+      expect(tokens[16]).toEqual value: 'from', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
+
+    it "tokenizes entire module import", ->
+      {tokens} = grammar.tokenizeLine('import * as name from "module-name";')
+      expect(tokens[0]).toEqual value: 'import', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
+      expect(tokens[1]).toEqual value: ' * ', scopes: ['source.js', 'meta.import.js']
+      expect(tokens[2]).toEqual value: 'as', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
+      expect(tokens[4]).toEqual value: 'name', scopes: ['source.js', 'meta.import.js']
       expect(tokens[6]).toEqual value: 'from', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
+
+    it "tokenizes `import defaultMember, { member } from 'module-name';`", ->
+      {tokens} = grammar.tokenizeLine('import defaultMember, { member } from "module-name";')
+      expect(tokens[0]).toEqual value: 'import', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
+      expect(tokens[2]).toEqual value: 'defaultMember', scopes: ['source.js', 'meta.import.js']
+      expect(tokens[3]).toEqual value: ',', scopes: ['source.js', 'meta.import.js', 'meta.delimiter.object.comma.js']
+      expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'meta.import.js', 'meta.brace.curly.js']
+      expect(tokens[7]).toEqual value: 'member', scopes: ['source.js', 'meta.import.js']
+      expect(tokens[9]).toEqual value: '}', scopes: ['source.js', 'meta.import.js', 'meta.brace.curly.js']
+      expect(tokens[11]).toEqual value: 'from', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
+
+    it "tokenizes `import defaultMember, * as alias from 'module-name';", ->
+      {tokens} = grammar.tokenizeLine('import defaultMember, * as alias from "module-name";')
+      expect(tokens[0]).toEqual value: 'import', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
+      expect(tokens[2]).toEqual value: 'defaultMember', scopes: ['source.js', 'meta.import.js']
+      expect(tokens[3]).toEqual value: ',', scopes: ['source.js', 'meta.import.js', 'meta.delimiter.object.comma.js']
+      expect(tokens[4]).toEqual value: ' * ', scopes: ['source.js', 'meta.import.js']
+      expect(tokens[5]).toEqual value: 'as', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
+      expect(tokens[7]).toEqual value: 'alias', scopes: ['source.js', 'meta.import.js']
+      expect(tokens[9]).toEqual value: 'from', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
 
   describe "ES6 yield", ->
     it "tokenizes yield", ->

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -505,26 +505,26 @@ describe "Javascript grammar", ->
   describe "ES6 export", ->
     it "tokenizes named export", ->
       {tokens} = grammar.tokenizeLine('export var x = 0;')
-      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
       expect(tokens[2]).toEqual value: 'var', scopes: ['source.js', 'storage.modifier.js']
       expect(tokens[3]).toEqual value: ' x ', scopes: ['source.js']
       expect(tokens[4]).toEqual value: '=', scopes: ['source.js', 'keyword.operator.js']
 
       {tokens} = grammar.tokenizeLine('export let scopedVariable = 0;')
-      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
       expect(tokens[2]).toEqual value: 'let', scopes: ['source.js', 'storage.modifier.js']
       expect(tokens[3]).toEqual value: ' scopedVariable ', scopes: ['source.js']
       expect(tokens[4]).toEqual value: '=', scopes: ['source.js', 'keyword.operator.js']
 
       {tokens} = grammar.tokenizeLine('export const CONSTANT = 0;')
-      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
       expect(tokens[2]).toEqual value: 'const', scopes: ['source.js', 'storage.modifier.js']
       expect(tokens[4]).toEqual value: 'CONSTANT', scopes: ['source.js', 'constant.other.js']
       expect(tokens[6]).toEqual value: '=', scopes: ['source.js', 'keyword.operator.js']
 
     it "tokenizes named function export", ->
       {tokens} = grammar.tokenizeLine('export function func(p1, p2){}')
-      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
       expect(tokens[2]).toEqual value: 'function', scopes: ['source.js', 'meta.function.js', 'storage.type.function.js']
       expect(tokens[4]).toEqual value: 'func', scopes: ['source.js', 'meta.function.js', 'entity.name.function.js']
       expect(tokens[5]).toEqual value: '(', scopes: ['source.js', 'meta.function.js', 'punctuation.definition.parameters.begin.js']
@@ -535,50 +535,59 @@ describe "Javascript grammar", ->
 
     it "tokenizes named class export", ->
       {tokens} = grammar.tokenizeLine('export class Foo {}')
-      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
       expect(tokens[2]).toEqual value: 'class', scopes: ['source.js', 'meta.class.js', 'storage.type.class.js']
       expect(tokens[4]).toEqual value: 'Foo', scopes: ['source.js', 'meta.class.js', 'entity.name.type.js']
 
     it "tokenizes existing variable export", ->
       {tokens} = grammar.tokenizeLine('export { bar };')
-      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
-      expect(tokens[2]).toEqual value: '{', scopes: ['source.js', 'meta.brace.curly.js']
-      expect(tokens[4]).toEqual value: '}', scopes: ['source.js', 'meta.brace.curly.js']
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
+      expect(tokens[2]).toEqual value: '{', scopes: ['source.js', 'meta.export.js', 'punctuation.definition.modules.begin.js']
+      expect(tokens[4]).toEqual value: 'bar', scopes: ['source.js', 'meta.export.js', 'variable.other.module.js']
+      expect(tokens[6]).toEqual value: '}', scopes: ['source.js', 'meta.export.js', 'punctuation.definition.modules.end.js']
 
       {tokens} = grammar.tokenizeLine('export { bar, foo as alias };')
-      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
-      expect(tokens[2]).toEqual value: '{', scopes: ['source.js', 'meta.brace.curly.js']
-      expect(tokens[4]).toEqual value: ',', scopes: ['source.js', 'meta.delimiter.object.comma.js']
-      expect(tokens[6]).toEqual value: '}', scopes: ['source.js', 'meta.brace.curly.js']
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
+      expect(tokens[2]).toEqual value: '{', scopes: ['source.js', 'meta.export.js', 'punctuation.definition.modules.begin.js']
+      expect(tokens[4]).toEqual value: 'bar', scopes: ['source.js', 'meta.export.js', 'variable.other.module.js']
+      expect(tokens[5]).toEqual value: ',', scopes: ['source.js', 'meta.export.js', 'meta.delimiter.object.comma.js']
+      expect(tokens[7]).toEqual value: 'foo', scopes: ['source.js', 'meta.export.js', 'variable.other.module.js']
+      expect(tokens[9]).toEqual value: 'as', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
+      expect(tokens[11]).toEqual value: 'alias', scopes: ['source.js', 'meta.export.js', 'variable.other.module-alias.js']
+      expect(tokens[13]).toEqual value: '}', scopes: ['source.js', 'meta.export.js', 'punctuation.definition.modules.end.js']
 
     it "tokenizes default export", ->
       {tokens} = grammar.tokenizeLine('export default 123;')
-      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
-      expect(tokens[2]).toEqual value: 'default', scopes: ['source.js', 'keyword.control.js']
-      expect(tokens[4]).toEqual value: '123', scopes: ['source.js', 'constant.numeric.js']
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
+      expect(tokens[2]).toEqual value: 'default', scopes: ['source.js', 'meta.export.js', 'variable.language.default.js']
+      expect(tokens[4]).toEqual value: '123', scopes: ['source.js', 'meta.export.js', 'constant.numeric.js']
 
       {tokens} = grammar.tokenizeLine('export default name;')
-      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
-      expect(tokens[2]).toEqual value: 'default', scopes: ['source.js', 'keyword.control.js']
-      expect(tokens[3]).toEqual value: ' name', scopes: ['source.js']
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
+      expect(tokens[2]).toEqual value: 'default', scopes: ['source.js', 'meta.export.js', 'variable.language.default.js']
+      expect(tokens[4]).toEqual value: 'name', scopes: ['source.js', 'meta.export.js', 'variable.other.module.js']
 
       {tokens} = grammar.tokenizeLine('export { foo as default };')
-      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
-      expect(tokens[2]).toEqual value: '{', scopes: ['source.js', 'meta.brace.curly.js']
-      expect(tokens[4]).toEqual value: 'default', scopes: ['source.js', 'keyword.control.js']
-      expect(tokens[6]).toEqual value: '}', scopes: ['source.js', 'meta.brace.curly.js']
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
+      expect(tokens[2]).toEqual value: '{', scopes: ['source.js', 'meta.export.js', 'punctuation.definition.modules.begin.js']
+      expect(tokens[4]).toEqual value: 'foo', scopes: ['source.js', 'meta.export.js', 'variable.other.module.js']
+      expect(tokens[6]).toEqual value: 'as', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
+      expect(tokens[8]).toEqual value: 'default', scopes: ['source.js', 'meta.export.js', 'variable.language.default.js']
+      expect(tokens[10]).toEqual value: '}', scopes: ['source.js', 'meta.export.js', 'punctuation.definition.modules.end.js']
 
     it "tokenizes default function export", ->
       {tokens} = grammar.tokenizeLine('export default function () {}')
-      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
-      expect(tokens[2]).toEqual value: 'default', scopes: ['source.js', 'keyword.control.js']
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
+      expect(tokens[2]).toEqual value: 'default', scopes: ['source.js', 'meta.export.js', 'variable.language.default.js']
       expect(tokens[4]).toEqual value: 'function', scopes: ['source.js', 'meta.function.js', 'storage.type.function.js']
       expect(tokens[6]).toEqual value: '(', scopes: ['source.js', 'meta.function.js', 'punctuation.definition.parameters.begin.js']
       expect(tokens[7]).toEqual value: ')', scopes: ['source.js', 'meta.function.js', 'punctuation.definition.parameters.end.js']
+      expect(tokens[9]).toEqual value: '{', scopes: ['source.js', 'punctuation.section.scope.begin.js']
+      expect(tokens[10]).toEqual value: '}', scopes: ['source.js', 'punctuation.section.scope.end.js']
 
       {tokens} = grammar.tokenizeLine('export default function func() {}')
-      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
-      expect(tokens[2]).toEqual value: 'default', scopes: ['source.js', 'keyword.control.js']
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
+      expect(tokens[2]).toEqual value: 'default', scopes: ['source.js', 'meta.export.js', 'variable.language.default.js']
       expect(tokens[4]).toEqual value: 'function', scopes: ['source.js', 'meta.function.js', 'storage.type.function.js']
       expect(tokens[6]).toEqual value: 'func', scopes: ['source.js', 'meta.function.js', 'entity.name.function.js']
       expect(tokens[7]).toEqual value: '(', scopes: ['source.js', 'meta.function.js', 'punctuation.definition.parameters.begin.js']
@@ -587,34 +596,39 @@ describe "Javascript grammar", ->
 
     it "tokenizes default class export", ->
       {tokens} = grammar.tokenizeLine('export default class {}')
-      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
-      expect(tokens[2]).toEqual value: 'default', scopes: ['source.js', 'keyword.control.js']
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
+      expect(tokens[2]).toEqual value: 'default', scopes: ['source.js', 'meta.export.js', 'variable.language.default.js']
       expect(tokens[4]).toEqual value: 'class', scopes: ['source.js', 'storage.type.js']
+      expect(tokens[6]).toEqual value: '{', scopes: ['source.js', 'punctuation.section.scope.begin.js']
+      expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'punctuation.section.scope.end.js']
 
       {tokens} = grammar.tokenizeLine('export default class Foo {}')
-      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
-      expect(tokens[2]).toEqual value: 'default', scopes: ['source.js', 'keyword.control.js']
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
+      expect(tokens[2]).toEqual value: 'default', scopes: ['source.js', 'meta.export.js', 'variable.language.default.js']
       expect(tokens[4]).toEqual value: 'class', scopes: ['source.js', 'meta.class.js', 'storage.type.class.js']
       expect(tokens[6]).toEqual value: 'Foo', scopes: ['source.js', 'meta.class.js', 'entity.name.type.js']
 
     it "tokenizes re-export", ->
       {tokens} = grammar.tokenizeLine('export { name } from "module-name";')
-      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
-      expect(tokens[2]).toEqual value: '{', scopes: ['source.js', 'meta.brace.curly.js']
-      expect(tokens[4]).toEqual value: '}', scopes: ['source.js', 'meta.brace.curly.js']
-      expect(tokens[6]).toEqual value: 'from', scopes: ['source.js', 'keyword.control.js']
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
+      expect(tokens[2]).toEqual value: '{', scopes: ['source.js', 'meta.export.js', 'punctuation.definition.modules.begin.js']
+      expect(tokens[4]).toEqual value: 'name', scopes: ['source.js', 'meta.export.js', 'variable.other.module.js']
+      expect(tokens[6]).toEqual value: '}', scopes: ['source.js', 'meta.export.js', 'punctuation.definition.modules.end.js']
+      expect(tokens[8]).toEqual value: 'from', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
 
       {tokens} = grammar.tokenizeLine('export * from "module-name";')
-      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
-      expect(tokens[2]).toEqual value: '*', scopes: ['source.js', 'keyword.operator.js']
-      expect(tokens[4]).toEqual value: 'from', scopes: ['source.js', 'keyword.control.js']
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
+      expect(tokens[2]).toEqual value: '*', scopes: ['source.js', 'meta.export.js', 'variable.language.import-all.js']
+      expect(tokens[4]).toEqual value: 'from', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
 
       {tokens} = grammar.tokenizeLine('export { default as alias } from "module-name";')
-      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
-      expect(tokens[2]).toEqual value: '{', scopes: ['source.js', 'meta.brace.curly.js']
-      expect(tokens[4]).toEqual value: 'default', scopes: ['source.js', 'keyword.control.js']
-      expect(tokens[6]).toEqual value: '}', scopes: ['source.js', 'meta.brace.curly.js']
-      expect(tokens[8]).toEqual value: 'from', scopes: ['source.js', 'keyword.control.js']
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
+      expect(tokens[2]).toEqual value: '{', scopes: ['source.js', 'meta.export.js', 'punctuation.definition.modules.begin.js']
+      expect(tokens[4]).toEqual value: 'default', scopes: ['source.js', 'meta.export.js', 'variable.language.default.js']
+      expect(tokens[6]).toEqual value: 'as', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
+      expect(tokens[8]).toEqual value: 'alias', scopes: ['source.js', 'meta.export.js', 'variable.other.module-alias.js']
+      expect(tokens[10]).toEqual value: '}', scopes: ['source.js', 'meta.export.js', 'punctuation.definition.modules.end.js']
+      expect(tokens[12]).toEqual value: 'from', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
 
   describe "ES6 yield", ->
     it "tokenizes yield", ->

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -498,6 +498,120 @@ describe "Javascript grammar", ->
       expect(tokens[7]).toEqual value: 'alias', scopes: ['source.js', 'meta.import.js']
       expect(tokens[9]).toEqual value: 'from', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
 
+  describe "ES6 export", ->
+    it "tokenizes named export", ->
+      {tokens} = grammar.tokenizeLine('export var x = 0;')
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[2]).toEqual value: 'var', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[3]).toEqual value: ' x ', scopes: ['source.js']
+      expect(tokens[4]).toEqual value: '=', scopes: ['source.js', 'keyword.operator.js']
+
+      {tokens} = grammar.tokenizeLine('export let scopedVariable = 0;')
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[2]).toEqual value: 'let', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[3]).toEqual value: ' scopedVariable ', scopes: ['source.js']
+      expect(tokens[4]).toEqual value: '=', scopes: ['source.js', 'keyword.operator.js']
+
+      {tokens} = grammar.tokenizeLine('export const CONSTANT = 0;')
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[2]).toEqual value: 'const', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[4]).toEqual value: 'CONSTANT', scopes: ['source.js', 'constant.other.js']
+      expect(tokens[6]).toEqual value: '=', scopes: ['source.js', 'keyword.operator.js']
+
+    it "tokenizes named function export", ->
+      {tokens} = grammar.tokenizeLine('export function func(p1, p2){}')
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[2]).toEqual value: 'function', scopes: ['source.js', 'meta.function.js', 'storage.type.function.js']
+      expect(tokens[4]).toEqual value: 'func', scopes: ['source.js', 'meta.function.js', 'entity.name.function.js']
+      expect(tokens[5]).toEqual value: '(', scopes: ['source.js', 'meta.function.js', 'punctuation.definition.parameters.begin.js']
+      expect(tokens[6]).toEqual value: 'p1', scopes: ['source.js', 'meta.function.js', 'variable.parameter.function.js']
+      expect(tokens[7]).toEqual value: ',', scopes: ['source.js', 'meta.function.js', 'meta.object.delimiter.js']
+      expect(tokens[9]).toEqual value: 'p2', scopes: ['source.js', 'meta.function.js', 'variable.parameter.function.js']
+      expect(tokens[10]).toEqual value: ')', scopes: ['source.js', 'meta.function.js', 'punctuation.definition.parameters.end.js']
+
+    it "tokenizes named class export", ->
+      {tokens} = grammar.tokenizeLine('export class Foo {}')
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[2]).toEqual value: 'class', scopes: ['source.js', 'meta.class.js', 'storage.type.class.js']
+      expect(tokens[4]).toEqual value: 'Foo', scopes: ['source.js', 'meta.class.js', 'entity.name.type.js']
+
+    it "tokenizes existing variable export", ->
+      {tokens} = grammar.tokenizeLine('export { bar };')
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[2]).toEqual value: '{', scopes: ['source.js', 'meta.brace.curly.js']
+      expect(tokens[4]).toEqual value: '}', scopes: ['source.js', 'meta.brace.curly.js']
+
+      {tokens} = grammar.tokenizeLine('export { bar, foo as alias };')
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[2]).toEqual value: '{', scopes: ['source.js', 'meta.brace.curly.js']
+      expect(tokens[4]).toEqual value: ',', scopes: ['source.js', 'meta.delimiter.object.comma.js']
+      expect(tokens[6]).toEqual value: '}', scopes: ['source.js', 'meta.brace.curly.js']
+
+    it "tokenizes default export", ->
+      {tokens} = grammar.tokenizeLine('export default 123;')
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[2]).toEqual value: 'default', scopes: ['source.js', 'keyword.control.js']
+      expect(tokens[4]).toEqual value: '123', scopes: ['source.js', 'constant.numeric.js']
+
+      {tokens} = grammar.tokenizeLine('export default name;')
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[2]).toEqual value: 'default', scopes: ['source.js', 'keyword.control.js']
+      expect(tokens[3]).toEqual value: ' name', scopes: ['source.js']
+
+      {tokens} = grammar.tokenizeLine('export { foo as default };')
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[2]).toEqual value: '{', scopes: ['source.js', 'meta.brace.curly.js']
+      expect(tokens[4]).toEqual value: 'default', scopes: ['source.js', 'keyword.control.js']
+      expect(tokens[6]).toEqual value: '}', scopes: ['source.js', 'meta.brace.curly.js']
+
+    it "tokenizes default function export", ->
+      {tokens} = grammar.tokenizeLine('export default function () {}')
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[2]).toEqual value: 'default', scopes: ['source.js', 'keyword.control.js']
+      expect(tokens[4]).toEqual value: 'function', scopes: ['source.js', 'meta.function.js', 'storage.type.function.js']
+      expect(tokens[6]).toEqual value: '(', scopes: ['source.js', 'meta.function.js', 'punctuation.definition.parameters.begin.js']
+      expect(tokens[7]).toEqual value: ')', scopes: ['source.js', 'meta.function.js', 'punctuation.definition.parameters.end.js']
+
+      {tokens} = grammar.tokenizeLine('export default function func() {}')
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[2]).toEqual value: 'default', scopes: ['source.js', 'keyword.control.js']
+      expect(tokens[4]).toEqual value: 'function', scopes: ['source.js', 'meta.function.js', 'storage.type.function.js']
+      expect(tokens[6]).toEqual value: 'func', scopes: ['source.js', 'meta.function.js', 'entity.name.function.js']
+      expect(tokens[7]).toEqual value: '(', scopes: ['source.js', 'meta.function.js', 'punctuation.definition.parameters.begin.js']
+      expect(tokens[8]).toEqual value: ')', scopes: ['source.js', 'meta.function.js', 'punctuation.definition.parameters.end.js']
+
+
+    it "tokenizes default class export", ->
+      {tokens} = grammar.tokenizeLine('export default class {}')
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[2]).toEqual value: 'default', scopes: ['source.js', 'keyword.control.js']
+      expect(tokens[4]).toEqual value: 'class', scopes: ['source.js', 'storage.type.js']
+
+      {tokens} = grammar.tokenizeLine('export default class Foo {}')
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[2]).toEqual value: 'default', scopes: ['source.js', 'keyword.control.js']
+      expect(tokens[4]).toEqual value: 'class', scopes: ['source.js', 'meta.class.js', 'storage.type.class.js']
+      expect(tokens[6]).toEqual value: 'Foo', scopes: ['source.js', 'meta.class.js', 'entity.name.type.js']
+
+    it "tokenizes re-export", ->
+      {tokens} = grammar.tokenizeLine('export { name } from "module-name";')
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[2]).toEqual value: '{', scopes: ['source.js', 'meta.brace.curly.js']
+      expect(tokens[4]).toEqual value: '}', scopes: ['source.js', 'meta.brace.curly.js']
+      expect(tokens[6]).toEqual value: 'from', scopes: ['source.js', 'keyword.control.js']
+
+      {tokens} = grammar.tokenizeLine('export * from "module-name";')
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[2]).toEqual value: '*', scopes: ['source.js', 'keyword.operator.js']
+      expect(tokens[4]).toEqual value: 'from', scopes: ['source.js', 'keyword.control.js']
+
+      {tokens} = grammar.tokenizeLine('export { default as alias } from "module-name";')
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'storage.modifier.js']
+      expect(tokens[2]).toEqual value: '{', scopes: ['source.js', 'meta.brace.curly.js']
+      expect(tokens[4]).toEqual value: 'default', scopes: ['source.js', 'keyword.control.js']
+      expect(tokens[6]).toEqual value: '}', scopes: ['source.js', 'meta.brace.curly.js']
+      expect(tokens[8]).toEqual value: 'from', scopes: ['source.js', 'keyword.control.js']
+
   describe "ES6 yield", ->
     it "tokenizes yield", ->
       {tokens} = grammar.tokenizeLine('yield next')


### PR DESCRIPTION
Fixes #232
```js
export var x = 0;
export const CONSTANT = 0;
export let scopedVariable = 0;
export function func(p1, p2){}
export class Foo {}
export { bar };
export { bar, foo as alias };
export default "string";
export default 123 + 23;
export default name;
export default function () {}
export default function func() {}
export default class {}
export default class Foo {}
export { foo as default };
export { name } from 'module-name';
export * from 'module-name';
export { default as alias } from 'module-name';
export { default as alias }; //illegal
export { name as * }; //illegal
import "module-name";
import * as name from "module-name"
import defaultMember from "module-name";
import { member } from "module-name";
import { default as defaultMember } from "module-name";
import { member1 , member2 as alias2 } from "module-name";
import { member1 , member2 as default } from "module-name"; //illegal
import { member1 , member2 as * } from "module-name"; //illegal
import defaultMember, { member } from "module-name";
import defaultMember, * as alias from "module-name";
import defaultMember, * as alias from "module-name";
```
![atom-dark](https://cloud.githubusercontent.com/assets/2943616/10314087/a838fb38-6c5b-11e5-8dab-b57a2a87fa2f.png)
> Atom Dark

![one-dark](https://cloud.githubusercontent.com/assets/2943616/10314094/ac22f064-6c5b-11e5-9c7c-b635be7550cf.png)
> One Dark

![monokai](https://cloud.githubusercontent.com/assets/2943616/10314097/ae2f724c-6c5b-11e5-8400-640cea8712ab.png)
> Monokai
