### PR TITLE
Capture regular braces before ending interpolation

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -670,7 +670,7 @@
         'name': 'meta.brace.round.js'
       }
       {
-        'match': '\\{|\\}'
+        'match': '{|}'
         'name': 'meta.brace.curly.js'
       }
       {
@@ -829,10 +829,10 @@
       '2':
         'name': 'punctuation.section.scope.end.js'
     'comment': 'Allows the special return snippet to fire.'
-    'match': '(\\{)(\\})'
+    'match': '({)(})'
   }
   {
-    'match': '\\{|\\}'
+    'match': '{|}'
     'name': 'meta.brace.curly.js'
   }
   {
@@ -969,14 +969,16 @@
       {
         'name': 'meta.method.js'
         'comment': 'match regular function like: function myFunc(arg) { … }'
-
         'begin': '\\b((?!(?:break|case|catch|continue|do|else|finally|for|function|if|export|import|package|return|switch|throw|try|while|with)[\\s\\(])(?:[a-zA-Z_$][a-zA-Z_$0-9]*))\\s*(\\()(?=(?:[^\\(\\)]*)?\\)\\s*\\{)'
         'beginCaptures':
           '1':
             'name': 'entity.name.function.js'
           '2':
             'name': 'punctuation.definition.parameters.begin.js'
-
+        'end': '(\\))'
+        'endCaptures':
+          '1':
+            'name': 'punctuation.definition.parameters.end.js'
         'patterns': [
           {
             'include': '#function-params'
@@ -985,11 +987,6 @@
             'include': '#strings'
           }
         ]
-
-        'end': '(\\))'
-        'endCaptures':
-          '1':
-            'name': 'punctuation.definition.parameters.end.js'
       }
     ]
   'function-params':
@@ -1009,7 +1006,7 @@
         'name': 'meta.brace.square.js'
       }
       {
-        'match': '\\{|\\}'
+        'match': '{|}'
         'name': 'meta.brace.curly.js'
       }
       {
@@ -1038,6 +1035,21 @@
         'end': '\\}'
         'name': 'source.js.embedded.source'
         'patterns': [
+          {
+            'begin': '{'
+            'beginCaptures':
+              '0':
+                'name': 'meta.brace.curly.js'
+            'end': '}'
+            'endCaptures':
+              '0':
+                'name': 'meta.brace.curly.js'
+            'patterns': [
+              {
+                'include': '$self'
+              }
+            ]
+          }
           {
             'include': '$self'
           }

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -451,6 +451,21 @@ describe "Javascript grammar", ->
       expect(tokens[4]).toEqual value: '}', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'punctuation.section.embedded.js']
       expect(tokens[5]).toEqual value: '`', scopes: ['source.js', 'string.quoted.template.js', 'punctuation.definition.string.end.js']
 
+      {tokens} = grammar.tokenizeLine('`hey ${() => {return hi;}}`')
+      expect(tokens[0]).toEqual value: '`', scopes: ['source.js', 'string.quoted.template.js', 'punctuation.definition.string.begin.js']
+      expect(tokens[1]).toEqual value: 'hey ', scopes: ['source.js', 'string.quoted.template.js']
+      expect(tokens[2]).toEqual value: '${', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'punctuation.section.embedded.js']
+      expect(tokens[3]).toEqual value: '(', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'meta.function.arrow.js', 'punctuation.definition.parameters.begin.js']
+      expect(tokens[4]).toEqual value: ')', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'meta.function.arrow.js', 'punctuation.definition.parameters.end.js']
+      expect(tokens[5]).toEqual value: ' =>', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'meta.function.arrow.js', 'storage.type.arrow.js']
+      expect(tokens[7]).toEqual value: '{', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'meta.brace.curly.js']
+      expect(tokens[8]).toEqual value: 'return', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'keyword.control.js']
+      expect(tokens[9]).toEqual value: ' hi', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source']
+      expect(tokens[10]).toEqual value: ';', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'punctuation.terminator.statement.js']
+      expect(tokens[11]).toEqual value: '}', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'meta.brace.curly.js']
+      expect(tokens[12]).toEqual value: '}', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'punctuation.section.embedded.js']
+      expect(tokens[13]).toEqual value: '`', scopes: ['source.js', 'string.quoted.template.js', 'punctuation.definition.string.end.js']
+
   describe "ES6 class", ->
     it "tokenizes class", ->
       {tokens} = grammar.tokenizeLine('class MyClass')


### PR DESCRIPTION
Fixes #199.  Also includes some very minor style fixes.

In the future I'd like to combine all the `meta.brace.*.js` patterns into their own `braces` block, but that was too much work for this.

/cc @schmittyjd, @methodgrab