### PR TITLE
Don't capture whitespace as `storage.type.arrow.js`

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -517,8 +517,7 @@
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.parameters.begin.js'
-
-    'end': '(\\))(\\s*=>)'
+    'end': '(\\))\\s*(=>)'
     'endCaptures':
       '1':
         'name': 'punctuation.definition.parameters.end.js'
@@ -541,7 +540,7 @@
         'name': 'keyword.operator.assignment.js'
       '3':
         'name': 'punctuation.definition.parameters.begin.js'
-    'end': '(\\))(\\s*=>)'
+    'end': '(\\))\\s*(=>)'
     'endCaptures':
       '1':
         'name': 'punctuation.definition.parameters.end.js'
@@ -566,7 +565,7 @@
         'name': 'keyword.operator.assignment.js'
       '4':
         'name': 'punctuation.definition.parameters.begin.js'
-    'end': '(\\))(\\s*=>)'
+    'end': '(\\))\\s*(=>)'
     'endCaptures':
       '1':
         'name': 'punctuation.definition.parameters.end.js'

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -467,14 +467,14 @@ describe "Javascript grammar", ->
       expect(tokens[2]).toEqual value: '${', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'punctuation.section.embedded.js']
       expect(tokens[3]).toEqual value: '(', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'meta.function.arrow.js', 'punctuation.definition.parameters.begin.js']
       expect(tokens[4]).toEqual value: ')', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'meta.function.arrow.js', 'punctuation.definition.parameters.end.js']
-      expect(tokens[5]).toEqual value: ' =>', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'meta.function.arrow.js', 'storage.type.arrow.js']
-      expect(tokens[7]).toEqual value: '{', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'meta.brace.curly.js']
-      expect(tokens[8]).toEqual value: 'return', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'keyword.control.js']
-      expect(tokens[9]).toEqual value: ' hi', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source']
-      expect(tokens[10]).toEqual value: ';', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'punctuation.terminator.statement.js']
-      expect(tokens[11]).toEqual value: '}', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'meta.brace.curly.js']
-      expect(tokens[12]).toEqual value: '}', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'punctuation.section.embedded.js']
-      expect(tokens[13]).toEqual value: '`', scopes: ['source.js', 'string.quoted.template.js', 'punctuation.definition.string.end.js']
+      expect(tokens[6]).toEqual value: '=>', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'meta.function.arrow.js', 'storage.type.arrow.js']
+      expect(tokens[8]).toEqual value: '{', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'meta.brace.curly.js']
+      expect(tokens[9]).toEqual value: 'return', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'keyword.control.js']
+      expect(tokens[10]).toEqual value: ' hi', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source']
+      expect(tokens[11]).toEqual value: ';', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'punctuation.terminator.statement.js']
+      expect(tokens[12]).toEqual value: '}', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'meta.brace.curly.js']
+      expect(tokens[13]).toEqual value: '}', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'punctuation.section.embedded.js']
+      expect(tokens[14]).toEqual value: '`', scopes: ['source.js', 'string.quoted.template.js', 'punctuation.definition.string.end.js']
 
   describe "ES6 class", ->
     it "tokenizes class", ->

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -830,7 +830,7 @@ describe "Javascript grammar", ->
       expect(tokens[7]).toEqual value: 'param1', scopes: ['source.js', 'meta.function.arrow.js', 'variable.parameter.function.js']
       expect(tokens[10]).toEqual value: 'param2', scopes: ['source.js', 'meta.function.arrow.js', 'variable.parameter.function.js']
       expect(tokens[11]).toEqual value: ')', scopes: ['source.js', 'meta.function.arrow.js', 'punctuation.definition.parameters.end.js']
-      expect(tokens[12]).toEqual value: ' =>', scopes: ['source.js', 'meta.function.arrow.js', 'storage.type.arrow.js']
+      expect(tokens[13]).toEqual value: '=>', scopes: ['source.js', 'meta.function.arrow.js', 'storage.type.arrow.js']
 
   describe "strings and functions", ->
     it "doesn't confuse them", ->


### PR DESCRIPTION
Self-explanatory.  Only the arrow itself should be captured.