### PR TITLE
Add support for OpenJsCad

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -10,6 +10,7 @@
   'pjs'
   'xsjs'
   'xsjslib'
+  'jscad'
 ]
 'firstLineMatch': '^#!.*\\b(node|iojs|JavaScript)'
 'name': 'JavaScript'

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1,16 +1,16 @@
 'scopeName': 'source.js'
 'fileTypes': [
   'js'
-  'htc'
   '_js'
   'es'
   'es6'
+  'htc'
+  'jscad'
   'jsm'
   'pac'
   'pjs'
   'xsjs'
   'xsjslib'
-  'jscad'
 ]
 'firstLineMatch': '^#!.*\\b(node|iojs|JavaScript)'
 'name': 'JavaScript'


### PR DESCRIPTION
This pull requests adds support for `.jscad` files to have JavaScript syntax highlighting. This closes #247.