### PR TITLE
Support JSON5 files

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -7,6 +7,7 @@
   'htc'
   'jscad'
   'jsm'
+  'json5'
   'pac'
   'pjs'
   'xsjs'


### PR DESCRIPTION
Hi there,

It'd be nice for Atom to recognize [`.json5` files](https://github.com/aseemk/json5) and syntax highlight them. Doing so as JavaScript is good enough — and is in fact what GitHub does too:

https://github.com/github/linguist/blob/c8b30a62f9caf50609e4abc515469a5dda9b9584/lib/linguist/languages.yml#L1581-L1586

I'm not sure if what I've done in this PR is the best way to achieve this, though. Please feel free to let me know if I should do it differently. For now, I did the same thing I did for `._js` (pull #4).

Thanks!