### PR TITLE
Support gradle files

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -12,6 +12,7 @@
   'pjs'
   'xsjs'
   'xsjslib'
+  'gradle'
 ]
 'firstLineMatch': '^#!.*\\b(node|iojs|JavaScript)'
 'name': 'JavaScript'


### PR DESCRIPTION
Hi. 

The Gradle syntax is really similar to the one from JavaScript, so the Syntax Highlighting from JavaScript can be used. I see other editors do the same.

I also tried this modifications with my local atom installation and it works great. 

I hope this can be merged upstream. 

Thanks. 
