### PR TITLE
Updated regex's for indentation

### DIFF
--- a/settings/language-javascript.cson
+++ b/settings/language-javascript.cson
@@ -2,11 +2,6 @@
   'editor':
     'commentStart': '// '
     'foldEndPattern': '^\\s*\\}|^\\s*\\]|^\\s*\\)'
-    'increaseIndentPattern': '(?x)
-        \\{ [^}"\']* $
-      | \\[ [^\\]"\']* $
-      | \\( [^)"\']* $
-      '
-    'decreaseIndentPattern': '(?x)
-        ^ \\s* (\\s* /[*] .* [*]/ \\s*)* [}\\])]
-      '
+    'decreaseIndentPattern': "^\\s*[\\}\\]\\)]"
+    'decreaseNextIndentPattern': "[\\}\\]\\)]"
+    'increaseIndentPattern': "[\\{\\[\\(]"

--- a/settings/language-javascript.cson
+++ b/settings/language-javascript.cson
@@ -2,6 +2,6 @@
   'editor':
     'commentStart': '// '
     'foldEndPattern': '^\\s*\\}|^\\s*\\]|^\\s*\\)'
-    'decreaseIndentPattern': "^\\s*[\\}\\]\\)]"
-    'decreaseNextIndentPattern': "[\\}\\]\\)]"
-    'increaseIndentPattern': "[\\{\\[\\(]"
+    decreaseThisIndentPattern: "^\\s*[\\}\\]\\)]"
+    decreaseIndentPattern: "[\\}\\]\\)]"
+    increaseIndentPattern: "[\\{\\[\\(]"


### PR DESCRIPTION
This is intended for use with the new language-mode logic of atom/atom
commit 544112516e362f8741f418a9876b36d9261dd13b.
(See PR https://github.com/atom/atom/pull/10367).

Fixes atom/atom#4983 (when used with the above mentioned commit in atom/atom).

