### PR TITLE
Add jsx to file types

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -13,6 +13,7 @@
   'pjs'
   'xsjs'
   'xsjslib'
+  'jsx'
 ]
 'firstLineMatch': '^#!.*\\b(node|iojs|JavaScript)'
 'name': 'JavaScript'


### PR DESCRIPTION
No JSX package on atom compares this one to parsing JavaScript. I'd like to just not use any of these packages in my `.jsx` files and just have `language-javascript` render them.