### PR TITLE
Add grammar to parse JSDoc variable type, variable name and description

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1500,10 +1500,14 @@
       {
         'match': '(\{\\b(?:[a-zA-Z_$][a-zA-Z_$0-9]*)\\b\})\\s\\b([a-zA-Z_$][a-zA-Z_$0-9]*)\\b\\s*(.*)'
         'captures':
-            0: 'name': 'other.meta.jsdoc'
-            1: 'name': 'entity.name.type.instance.jsdoc'
-            2: 'name': 'variable.other.jsdoc'
-            3: 'name': 'other.description.jsdoc'
+            0:
+              'name': 'other.meta.jsdoc'
+            1:
+              'name': 'entity.name.type.instance.jsdoc'
+            2:
+              'name': 'variable.other.jsdoc'
+            3:
+              'name': 'other.description.jsdoc'
       }
     ]
   'comments':

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1498,7 +1498,7 @@
         'name': 'storage.type.class.jsdoc'
       }
       {
-        'match': '(\{\\b(?:[a-zA-Z_$][a-zA-Z_$0-9]*)\\b\})\\s\\b([a-zA-Z_$][a-zA-Z_$0-9]*)\\b\\s*(.*)'
+        'match': '({\\b(?:[a-zA-Z_$][a-zA-Z_$0-9]*)\\b})\\s\\b([a-zA-Z_$][a-zA-Z_$0-9]*)\\b\\s*((?:(?!\\*\\/).)*)'
         'captures':
             0:
               'name': 'other.meta.jsdoc'

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1497,6 +1497,14 @@
         'match': '(?<!\\w)@(abstract|access|alias|augments|author|async|attribute|arg|argument|beta|borrows|bubbes|callback|class|classdesc|config|const|constant|constructs|constructor|copyright|chainable|default|defaultvalue|deprecated|desc|description|enum|emits|event|example|exports|external|extends|extension|extensionfor|extension_for|for|file|fileoverview|fires|final|function|global|host|ignore|implements|inheritdoc|inner|instance|interface|kind|lends|license|listens|main|member|memberof|method|mixex|mixin(?:s|)|module|name|namespace|override|overview|param|private|prop|property|protected|readonly|readOnly|requires|required|return|returns|see|since|static|summary|submodule|this|throws|todo|tutorial|type|typedef|var|variation|version|virtual|uses|writeOnce)\\b'
         'name': 'storage.type.class.jsdoc'
       }
+      {
+        'match': '(\{\\b(?:[a-zA-Z_$][a-zA-Z_$0-9]*)\\b\})\\s\\b([a-zA-Z_$][a-zA-Z_$0-9]*)\\b\\s*(.*)'
+        'captures':
+            0: 'name': 'other.meta.jsdoc'
+            1: 'name': 'entity.name.type.instance.jsdoc'
+            2: 'name': 'variable.other.jsdoc'
+            3: 'name': 'other.description.jsdoc'
+      }
     ]
   'comments':
     'patterns': [

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -1462,6 +1462,12 @@ describe "Javascript grammar", ->
       expect(tokens[3]).toEqual value: ' ', scopes: ['source.js', 'comment.block.documentation.js']
       expect(tokens[4]).toEqual value: '*/', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.definition.comment.js']
 
+    it "tokenizes JSDoc comment documentation", ->
+      {tokens} = grammar.tokenizeLine('/** @param {object} variable this is the description */')
+      expect(tokens[4]).toEqual value: '{object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
     it "tokenizes // comments", ->
       {tokens} = grammar.tokenizeLine('// comment')
       expect(tokens[0]).toEqual value: '//', scopes: ['source.js', 'comment.line.double-slash.js', 'punctuation.definition.comment.js']


### PR DESCRIPTION
This pull request adds grammar parsing for JSDoc variable type, variable name and description:

```js
/**
 * This is a title
 * @param {object} context this is a description
 */
```

... in which `{object} context this is a description` is now inside the scope of `other.meta.jsdoc`, `{object}` is `entity.name.type.instance.jsdoc`, `context` is `variable.other.jsdoc` and `this is a description` `other.description.jsdoc`.