### PR TITLE
[art] Make specs less verbose

### DIFF
--- a/spec/regular-expression-replacement-spec.coffee
+++ b/spec/regular-expression-replacement-spec.coffee
@@ -1,3 +1,5 @@
+{eq} = require './spec-helper'
+
 describe "Regular Expression Replacement grammar", ->
   grammar = null
 
@@ -15,71 +17,71 @@ describe "Regular Expression Replacement grammar", ->
   describe "basic strings", ->
     it "tokenizes with no extra scopes", ->
       {tokens} = grammar.tokenizeLine('Hello [world]. (hi to you)')
-      expect(tokens[0]).toEqual value: 'Hello [world]. (hi to you)', scopes: ['source.js.regexp.replacement']
+      eq tokens[0], 'Hello [world]. (hi to you)', scope: 'source.js.regexp.replacement'
 
   describe "escaped characters", ->
     it "tokenizes with as an escape character", ->
       {tokens} = grammar.tokenizeLine('\\n')
-      expect(tokens[0]).toEqual value: '\\n', scopes: ['source.js.regexp.replacement', 'constant.character.escape.backslash.regexp.replacement']
+      eq tokens[0], '\\n', scope: 'constant.character.escape.backslash.regexp.replacement'
 
     it "tokenizes '$$' as an escaped '$' character", ->
       {tokens} = grammar.tokenizeLine('$$')
-      expect(tokens[0]).toEqual value: '$$', scopes: ['source.js.regexp.replacement', 'constant.character.escape.dollar.regexp.replacement']
+      eq tokens[0], '$$', scope: 'constant.character.escape.dollar.regexp.replacement'
 
     it "doesn't treat '\\$' as an escaped '$' character", ->
       {tokens} = grammar.tokenizeLine('\\$')
-      expect(tokens[0]).toEqual value: '\\$', scopes: ['source.js.regexp.replacement']
+      eq tokens[0], '\\$', scope: 'source.js.regexp.replacement'
 
     it "tokenizes '$$1' as an escaped '$' character followed by a '1' character", ->
       {tokens} = grammar.tokenizeLine('$$1')
-      expect(tokens[0]).toEqual value: '$$', scopes: ['source.js.regexp.replacement', 'constant.character.escape.dollar.regexp.replacement']
-      expect(tokens[1]).toEqual value: '1', scopes: ['source.js.regexp.replacement']
+      eq tokens[0], '$$', scope: 'constant.character.escape.dollar.regexp.replacement'
+      eq tokens[1], '1', scope: 'source.js.regexp.replacement'
 
   describe "Numeric placeholders", ->
     it "doesn't tokenize $0 as a variable", ->
       {tokens} = grammar.tokenizeLine('$0')
-      expect(tokens[0]).toEqual value: '$0', scopes: ['source.js.regexp.replacement']
+      eq tokens[0], '$0', scope: 'source.js.regexp.replacement'
 
     it "doesn't tokenize $00 as a variable", ->
       {tokens} = grammar.tokenizeLine('$00')
-      expect(tokens[0]).toEqual value: '$00', scopes: ['source.js.regexp.replacement']
+      eq tokens[0], '$00', scope: 'source.js.regexp.replacement'
 
     it "tokenizes $1 as a variable", ->
       {tokens} = grammar.tokenizeLine('$1')
-      expect(tokens[0]).toEqual value: '$1', scopes: ['source.js.regexp.replacement', 'variable.regexp.replacement']
+      eq tokens[0], '$1', scope: 'variable.regexp.replacement'
 
     it "tokenizes $01 as a variable", ->
       {tokens} = grammar.tokenizeLine('$01')
-      expect(tokens[0]).toEqual value: '$01', scopes: ['source.js.regexp.replacement', 'variable.regexp.replacement']
+      eq tokens[0], '$01', scope: 'variable.regexp.replacement'
 
     it "tokenizes $3 as a variable", ->
       {tokens} = grammar.tokenizeLine('$3')
-      expect(tokens[0]).toEqual value: '$3', scopes: ['source.js.regexp.replacement', 'variable.regexp.replacement']
+      eq tokens[0], '$3', scope: 'variable.regexp.replacement'
 
     it "tokenizes $10 as a variable", ->
       {tokens} = grammar.tokenizeLine('$10')
-      expect(tokens[0]).toEqual value: '$10', scopes: ['source.js.regexp.replacement', 'variable.regexp.replacement']
+      eq tokens[0], '$10', scope: 'variable.regexp.replacement'
 
     it "tokenizes $99 as a variable", ->
       {tokens} = grammar.tokenizeLine('$99')
-      expect(tokens[0]).toEqual value: '$99', scopes: ['source.js.regexp.replacement', 'variable.regexp.replacement']
+      eq tokens[0], '$99', scope: 'variable.regexp.replacement'
 
     it "doesn't tokenize the third numberic character in '$100' as a variable", ->
       {tokens} = grammar.tokenizeLine('$100')
-      expect(tokens[0]).toEqual value: '$10', scopes: ['source.js.regexp.replacement', 'variable.regexp.replacement']
-      expect(tokens[1]).toEqual value: '0', scopes: ['source.js.regexp.replacement']
+      eq tokens[0], '$10', scope: 'variable.regexp.replacement'
+      eq tokens[1], '0', scope: 'source.js.regexp.replacement'
 
     describe "Matched sub-string placeholder", ->
       it "tokenizes $& as a variable", ->
         {tokens} = grammar.tokenizeLine('$&')
-        expect(tokens[0]).toEqual value: '$&', scopes: ['source.js.regexp.replacement', 'variable.regexp.replacement']
+        eq tokens[0], '$&', scope: 'variable.regexp.replacement'
 
     describe "Preceeding portion placeholder", ->
       it "tokenizes $` as a variable", ->
         {tokens} = grammar.tokenizeLine('$`')
-        expect(tokens[0]).toEqual value: '$`', scopes: ['source.js.regexp.replacement', 'variable.regexp.replacement']
+        eq tokens[0], '$`', scope: 'variable.regexp.replacement'
 
     describe "Following portion placeholder", ->
       it "tokenizes $' as a variable", ->
         {tokens} = grammar.tokenizeLine('$\'')
-        expect(tokens[0]).toEqual value: '$\'', scopes: ['source.js.regexp.replacement', 'variable.regexp.replacement']
+        eq tokens[0], '$\'', scope: 'variable.regexp.replacement'

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -10,11 +10,11 @@ module.exports =
     else if scopes?
       scopesArr = scopes.split(' ')
 
-      if scopesArr.length != token.scopes.length and scopesArr[0] == '_'
-          scopesArr[0] = token.scopes[0]
+      if scopesArr.length isnt token.scopes.length and scopesArr[0] is '_'
+        scopesArr[0] = token.scopes[0]
       else
         for key, scope of scopesArr
-          scopesArr[key] = token.scopes[key] if scope == '_'
+          scopesArr[key] = token.scopes[key] if scope is '_'
 
       expect(token).toEqual value: value, scopes: scopesArr
     else

--- a/spec/spec-helper.coffee
+++ b/spec/spec-helper.coffee
@@ -1,0 +1,21 @@
+module.exports =
+  eq: (token, value, {scopes, scope}) ->
+    if scope?
+      scopesArr = []
+      for key, scope of token.scopes
+        scopesArr[key] = token.scopes[key]
+      scopesArr[scopesArr.length - 1] = scope
+
+      expect(token).toEqual value: value, scopes: scopesArr
+    else if scopes?
+      scopesArr = scopes.split(' ')
+
+      if scopesArr.length != token.scopes.length and scopesArr[0] == '_'
+          scopesArr[0] = token.scopes[0]
+      else
+        for key, scope of scopesArr
+          scopesArr[key] = token.scopes[key] if scope == '_'
+
+      expect(token).toEqual value: value, scopes: scopesArr
+    else
+      expect(token).toEqual value: value


### PR DESCRIPTION
Compare `javascript-spec.coffee`: [before](https://github.com/atom/language-javascript/blob/82fffc468f995feec44f1b1581e6ba8ac95fb642/spec/javascript-spec.coffee) _vs_ [after](https://github.com/MaximSokolov/language-javascript/blob/59b1d0b3e7a8ba3bbb56e5dc966d904df3c47ca7/spec/javascript-spec.coffee)

**Before**/**After**:
`scope` tests only the latest scope

``` coffee
expect(tokens[0]).toEqual value: '0x1D306', scopes: ['source.js', 'constant.numeric.hex.js']
```

``` coffee
eq tokens[0], '0x1D306', scope: 'constant.numeric.hex.js'
```

**Before**/**After**:

``` coffee
expect(tokens[3]).toEqual value: '(', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'meta.function.arrow.js', 'meta.parameters.js', 'punctuation.definition.parameters.begin.bracket.round.js']
```

``` coffee
eq tokens[3], '(', scopes: '_ _ source.js.embedded.source _ _ punctuation.definition.parameters.begin.bracket.round.js'
```
#### Output

using "blank scope", and number of actual scopes less or above than expected 

``` coffee
eq tokens[1], '(', scopes: '_ _ meta.arguments.js punctuation.definition.arguments.begin.bracket.round.js'
```

``` diff
- 'name': 'meta.function-call.js'
```

```
Expected { value : '(', scopes : [ 'source.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js' ] }
to equal { value : '(', scopes : [ 'source.js', '_', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js' ] }
```

when there is no `scope(s)` argument

``` diff
- eq tokens[3], '/', scopes: '_ string.regexp.js punctuation.definition.string.begin.js'
+ eq tokens[3], '/', scopez: '_ string.regexp.js punctuation.definition.string.begin.js'
```

```
Expected { value : '/', scopes : [ 'source.js', 'string.regexp.js', 'punctuation.definition.string.begin.js' ] }
to equal { value : '/' }
```

in other cases output should be the same as before

``` coffee
eq tokens[2], 'b', scopes: '_ _ _ meta.function-call.js entity.name.function.js'
```

``` diff
- 'name': 'entity.name.function.js'
+ 'name': 'entity.name.function'
```

```
Expected { value : 'b', scopes : [ 'source.js', 'meta.function-call.js', 'meta.arguments.js', 'meta.function-call.js', 'entity.name.function' ] }
to equal { value : 'b', scopes : [ 'source.js', 'meta.function-call.js', 'meta.arguments.js', 'meta.function-call.js', 'entity.name.function.js' ] }
```

Thoughts? :thought_balloon:

Refs atom/language-html#109
