### PR TITLE
Add jsx file extension to fileTypes

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -2,6 +2,7 @@
 'fileTypes': [
   'js'
   '_js'
+  'jsx'
   'es'
   'es6'
   'gs'


### PR DESCRIPTION
`language-js` parses correctly `jsx` files (es6) but it isn't defined on fileTypes.

Turns out that I have to always change the language type to `Javascript` for `jsx` file types, which is very painful specially for those who use `.jsx` for **react components** files.