### PR TITLE
Improve multiline const destructuring

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -755,7 +755,7 @@
     'beginCaptures':
       '1':
         'name': 'storage.modifier.js'
-    'end': '(\\bof\\b|\\bin\\b)|(;)|(=)|(?<!,)\\n'
+    'end': '(\\bof\\b|\\bin\\b)|(;)|(=)|(?<![,{])\\n'
     'endCaptures':
       '1':
         'name': 'keyword.operator.$1.js'

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -415,6 +415,29 @@ describe "Javascript grammar", ->
       expect(lines[3][2]).toEqual value: 'a', scopes: ['source.js']
       expect(lines[3][3]).toEqual value: ')', scopes: ['source.js', 'meta.brace.round.js']
 
+      lines = grammar.tokenizeLines """
+        const {
+          a,
+          b,
+          c,
+        } = foo
+      """
+      expect(lines[0][0]).toEqual value: 'const', scopes: ['source.js', 'storage.modifier.js']
+      expect(lines[0][1]).toEqual value: ' ', scopes: ['source.js']
+      expect(lines[0][2]).toEqual value: '{', scopes: ['source.js', 'meta.brace.curly.js']
+      expect(lines[1][0]).toEqual value: '  ', scopes: ['source.js']
+      expect(lines[1][1]).toEqual value: 'a', scopes: ['source.js', 'constant.other.js']
+      expect(lines[1][2]).toEqual value: ',', scopes: ['source.js', 'meta.delimiter.object.comma.js']
+      expect(lines[2][0]).toEqual value: '  ', scopes: ['source.js']
+      expect(lines[2][1]).toEqual value: 'b', scopes: ['source.js', 'constant.other.js']
+      expect(lines[2][2]).toEqual value: ',', scopes: ['source.js', 'meta.delimiter.object.comma.js']
+      expect(lines[3][0]).toEqual value: '  ', scopes: ['source.js']
+      expect(lines[3][1]).toEqual value: 'c', scopes: ['source.js', 'constant.other.js']
+      expect(lines[4][0]).toEqual value: '}', scopes: ['source.js', 'meta.brace.curly.js']
+      expect(lines[4][1]).toEqual value: ' ', scopes: ['source.js']
+      expect(lines[4][2]).toEqual value: '=', scopes: ['source.js', 'keyword.operator.assignment.js']
+      expect(lines[4][3]).toEqual value: ' foo', scopes: ['source.js']
+
       {tokens} = grammar.tokenizeLine('(const hi);')
       expect(tokens[0]).toEqual value: '(', scopes: ['source.js', 'meta.brace.round.js']
       expect(tokens[1]).toEqual value: 'const', scopes: ['source.js', 'storage.modifier.js']


### PR DESCRIPTION
Current highlighting doesn't understand const destructuring when the _first variable_ isn't placed on the same line as the `const`. The same rule applies recursively for subobjects.

```js
// works for `a` here
const { a,
  b: {
    c, // doesn't work for `c` or `d`
    d,
  },
} = foo;

const { a,
  b: { c, // works for `c` and `d`
       d,
  },
} = foo;

// no variables highlighted
const {
	a,
	b: {
		c,
		d,
	},
} = foo;
```

With these changes:
![screen shot 2016-03-24 at 10 47 47](https://cloud.githubusercontent.com/assets/703602/14013654/e9dda8e0-f1ad-11e5-9450-4b2e4eaee243.png)
