### PR TITLE
Update Math highlighting.

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -724,6 +724,41 @@
     ]
   }
   {
+    # Math
+    'begin': '\\bMath\\b'
+    'beginCaptures':
+      '0':
+        'name': 'support.class.js'
+    'end': '(?!\\G)'
+    'patterns': [
+      {
+        # Math.random()
+        'begin': '\\s*(\\.)\\s*(abs|acos|acosh|asin|asinh|atan|atan2|atanh|cbrt|ceil|clz32|cos|cosh|exp|expm1|floor|fround|hypot|imul|log|log10|log1p|log2|max|min|pow|random|round|sign|sin|sinh|sqrt|tan|tanh|trunc)\\s*(?=\\()'
+        'beginCaptures':
+          '1':
+            'name': 'meta.delimiter.method.period.js'
+          '2':
+            'name': 'support.function.math.js'
+        'end': '(?<=\\))'
+        'name': 'meta.method-call.js'
+        'patterns': [
+          {
+            'include': '#arguments'
+          }
+        ]
+      }
+      {
+        # Math.PI
+        'match': '\\s*(\\.)\\s*(E|LN10|LN2|LOG10E|LOG2E|PI|SQRT1_2|SQRT2)\\b'
+        'captures':
+          '1':
+            'name': 'meta.delimiter.property.period.js'
+          '2':
+            'name': 'support.constant.property.math.js'
+      }
+    ]
+  }
+  {
     'include': '#strings'
   }
   {
@@ -869,7 +904,7 @@
     'name': 'support.class.js'
   }
   {
-    'match': '(\\.)(systemLanguage|scripts|scrollbars|screenX|screenY|screenTop|screenLeft|style|styleSheets|status|statusText|statusbar|siblingBelow|siblingAbove|source|suffixes|security|securityPolicy|selection|self|history|host|hostname|hash|hasFocus|XMLDocument|XSLDocument|next|namespaces|namespaceURI|nameProp|MIN_VALUE|MAX_VALUE|characterSet|constructor|controllers|cookieEnabled|colorDepth|components|complete|current|cpuClass|clip|clipBoardData|clientInformation|closed|classes|callee|caller|crypto|toolbar|top|textTransform|textIndent|textDecoration|textAlign|tags|SQRT1_2|SQRT2|innerHeight|innerWidth|input|ids|ignoreCase|zIndex|oscpu|onreadystatechange|onLine|outerHeight|outerWidth|opsProfile|opener|offscreenBuffering|NEGATIVE_INFINITY|display|dialogHeight|dialogTop|dialogWidth|dialogLeft|dialogArguments|directories|description|defaultStatus|defaultChecked|defaultCharset|defaultView|userProfile|userLanguage|userAgent|uniqueID|undefined|updateInterval|_content|pixelDepth|port|personalbar|pkcs11|plugins|platform|pathname|paddingRight|paddingBottom|paddingTop|paddingLeft|parent|parentWindow|parentLayer|pageX|pageXOffset|pageY|pageYOffset|protocol|prototype|product|productSub|prompter|previous|prefix|encoding|enabledPlugin|external|expando|embeds|visiblity|vendor|vendorSub|vLinkcolor|URLUnencoded|PI|POSITIVE_INFINITY|filename|fontSize|fontFamily|fontWeight|formName|frames|frameElement|fgColor|E|whiteSpace|listStyleType|lineHeight|linkColor|location|locationbar|localName|lowsrc|length|left|leftContext|lastModified|lastMatch|lastIndex|lastParen|layers|layerX|language|appMinorVersion|appName|appCodeName|appCore|appVersion|availHeight|availTop|availWidth|availLeft|all|arity|arguments|aLinkcolor|above|right|rightContext|responseXML|responeText|readyState|global|x|y|z|mimeTypes|multiline|menubar|marginRight|marginBottom|marginTop|marginLeft|LN10|LN2|LOG10E|LOG2E|bottom|border(Width|RightWidth|BottomWidth|Style|Color|TopWidth|LeftWidth)|bufferDepth|below|backgroundColor|backgroundImage)\\b'
+    'match': '(\\.)(systemLanguage|scripts|scrollbars|screenX|screenY|screenTop|screenLeft|style|styleSheets|status|statusText|statusbar|siblingBelow|siblingAbove|source|suffixes|security|securityPolicy|selection|self|history|host|hostname|hash|hasFocus|XMLDocument|XSLDocument|next|namespaces|namespaceURI|nameProp|MIN_VALUE|MAX_VALUE|characterSet|constructor|controllers|cookieEnabled|colorDepth|components|complete|current|cpuClass|clip|clipBoardData|clientInformation|closed|classes|callee|caller|crypto|toolbar|top|textTransform|textIndent|textDecoration|textAlign|tags|innerHeight|innerWidth|input|ids|ignoreCase|zIndex|oscpu|onreadystatechange|onLine|outerHeight|outerWidth|opsProfile|opener|offscreenBuffering|NEGATIVE_INFINITY|display|dialogHeight|dialogTop|dialogWidth|dialogLeft|dialogArguments|directories|description|defaultStatus|defaultChecked|defaultCharset|defaultView|userProfile|userLanguage|userAgent|uniqueID|undefined|updateInterval|_content|pixelDepth|port|personalbar|pkcs11|plugins|platform|pathname|paddingRight|paddingBottom|paddingTop|paddingLeft|parent|parentWindow|parentLayer|pageX|pageXOffset|pageY|pageYOffset|protocol|prototype|product|productSub|prompter|previous|prefix|encoding|enabledPlugin|external|expando|embeds|visiblity|vendor|vendorSub|vLinkcolor|URLUnencoded|POSITIVE_INFINITY|filename|fontSize|fontFamily|fontWeight|formName|frames|frameElement|fgColor|whiteSpace|listStyleType|lineHeight|linkColor|location|locationbar|localName|lowsrc|length|left|leftContext|lastModified|lastMatch|lastIndex|lastParen|layers|layerX|language|appMinorVersion|appName|appCodeName|appCore|appVersion|availHeight|availTop|availWidth|availLeft|all|arity|arguments|aLinkcolor|above|right|rightContext|responseXML|responeText|readyState|global|x|y|z|mimeTypes|multiline|menubar|marginRight|marginBottom|marginTop|marginLeft|bottom|border(Width|RightWidth|BottomWidth|Style|Color|TopWidth|LeftWidth)|bufferDepth|below|backgroundColor|backgroundImage)\\b'
     'captures':
       '1':
         'name': 'meta.delimiter.property.period.js'
@@ -1344,25 +1379,25 @@
               {
                 'match': '''(?x)
                   \\b(shift|showModelessDialog|showModalDialog|showHelp|scroll|scrollX|scrollByPages|
-                  scrollByLines|scrollY|scrollTo|stop|strike|sin|sizeToContent|sidebar|signText|sort|
+                  scrollByLines|scrollY|scrollTo|stop|strike|sizeToContent|sidebar|signText|sort|
                   sup|sub|substr|substring|splice|split|send|set(Milliseconds|Seconds|Minutes|Hours|
                   Month|Year|FullYear|Date|UTC(Milliseconds|Seconds|Minutes|Hours|Month|FullYear|Date)|
-                  Time|Hotkeys|Cursor|ZOptions|Active|Resizable|RequestHeader)|search|sqrt|slice|
-                  savePreferences|small|home|handleEvent|navigate|char|charCodeAt|charAt|cos|concat|
-                  contextual|confirm|compile|ceil|clear|captureEvents|call|createStyleSheet|createPopup|
+                  Time|Hotkeys|Cursor|ZOptions|Active|Resizable|RequestHeader)|search|slice|
+                  savePreferences|small|home|handleEvent|navigate|char|charCodeAt|charAt|concat|
+                  contextual|confirm|compile|clear|captureEvents|call|createStyleSheet|createPopup|
                   createEventObject|to(GMTString|UTCString|String|Source|UpperCase|LowerCase|LocaleString)|
-                  test|tan|taint|taintEnabled|indexOf|italics|disableExternalCapture|dump|detachEvent|unshift|
-                  untaint|unwatch|updateCommands|join|javaEnabled|pop|pow|push|plugins.refresh|paddings|parse|
-                  print|prompt|preference|enableExternalCapture|elementFromPoint|exp|exec|execScript|
+                  test|taint|taintEnabled|indexOf|italics|disableExternalCapture|dump|detachEvent|unshift|
+                  untaint|unwatch|updateCommands|join|javaEnabled|pop|push|plugins.refresh|paddings|parse|
+                  print|prompt|preference|enableExternalCapture|elementFromPoint|exec|execScript|
                   execCommand|valueOf|UTC|queryCommandState|queryCommandIndeterm|queryCommandEnabled|
                   queryCommandValue|find|file|fileModifiedDate|fileSize|fileCreatedDate|fileUpdatedDate|
-                  fixed|fontsize|fontcolor|forward|floor|fromCharCode|watch|link|load|log|lastIndexOf|
-                  asin|anchor|acos|attachEvent|atob|atan|atan2|apply|alert|abs|abort|round|routeEvents|
+                  fixed|fontsize|fontcolor|forward|fromCharCode|watch|link|load|lastIndexOf|
+                  anchor|attachEvent|atob|apply|alert|abort|routeEvents|
                   resize|resizeBy|resizeTo|recalc|returnValue|replace|reverse|reload|releaseCapture|
-                  releaseEvents|random|go|get(Milliseconds|Seconds|Minutes|Hours|Month|Day|Year|FullYear|
+                  releaseEvents|go|get(Milliseconds|Seconds|Minutes|Hours|Month|Day|Year|FullYear|
                   Time|Date|TimezoneOffset|UTC(Milliseconds|Seconds|Minutes|Hours|Day|Month|FullYear|Date)|
-                  Attention|Selection|ResponseHeader|AllResponseHeaders)|min|moveBy|moveBelow|moveTo|
-                  moveToAbsolute|moveAbove|mergeAttributes|match|margins|max|btoa|big|bold|borderWidths|blink|back)\\b
+                  Attention|Selection|ResponseHeader|AllResponseHeaders)|moveBy|moveBelow|moveTo|
+                  moveToAbsolute|moveAbove|mergeAttributes|match|margins|btoa|big|bold|borderWidths|blink|back)\\b
                 '''
                 'name': 'support.function.js'
               }

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -1552,6 +1552,24 @@ describe "Javascript grammar", ->
       expect(tokens[5]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
       expect(tokens[6]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
 
+  describe "math", ->
+    it "tokenizes the math object", ->
+      {tokens} = grammar.tokenizeLine('Math')
+      expect(tokens[0]).toEqual value: 'Math', scopes: ['source.js', 'support.class.js']
+
+    it "tokenizes math support functions/properties", ->
+      {tokens} = grammar.tokenizeLine('Math.random()')
+      expect(tokens[0]).toEqual value: 'Math', scopes: ['source.js', 'support.class.js']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+      expect(tokens[2]).toEqual value: 'random', scopes: ['source.js', 'meta.method-call.js', 'support.function.math.js']
+      expect(tokens[3]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
+      expect(tokens[4]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
+
+      {tokens} = grammar.tokenizeLine('Math.PI')
+      expect(tokens[0]).toEqual value: 'Math', scopes: ['source.js', 'support.class.js']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.property.period.js']
+      expect(tokens[2]).toEqual value: 'PI', scopes: ['source.js', 'support.constant.property.math.js']
+
   describe "indentation", ->
     editor = null
 


### PR DESCRIPTION
- Update [Math](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Math) methods and properties to ECMAScript 2015.
- Separate Math methods/properties from others so that they are only highlighted when preceded by the Math object (e.g. highlight `Math.random()` but not `foo.random()`).
- Add Math unit tests.