### PR TITLE
Add support for matching console as is, fix for issue 354

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -709,11 +709,6 @@
     'end': '(?!\\G)'
     'patterns': [
       {
-        # Match only console. When used as an object directly
-        # For eg. foo(console)
-        'match': '\\s*(?!\\.)'
-      }
-      {
         'begin': '\\s*(\\.)\\s*(assert|clear|debug|error|info|log|profile|profileEnd|time|timeEnd|warn)\\s*(?=\\()'
         'beginCaptures':
           '1':
@@ -727,6 +722,11 @@
             'include': '#arguments'
           }
         ]
+      }
+      {
+        # Match only console. When used as an object directly
+        # For eg. foo(console)
+        'match': '\\s*(?!\\.)'
       }
     ]
   }

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -709,6 +709,11 @@
     'end': '(?!\\G)'
     'patterns': [
       {
+        # Match only console. When used as an object directly
+        # For eg. foo(console)
+        'match': '\\s*(?!\\.)'
+      }
+      {
         'begin': '\\s*(\\.)\\s*(assert|clear|debug|error|info|log|profile|profileEnd|time|timeEnd|warn)\\s*(?=\\()'
         'beginCaptures':
           '1':


### PR DESCRIPTION
The current grammar expects `console` to be always used as `console.(log|error|etc.)()` function call. Although, it can also be passed to other functions, assigned etc. This is causing syntax issue as referenced in issue 354. This fix involves, matching `console` which is not directly followed by a period `.`