### PR TITLE
Prioritize HTML comments over regular comments

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -767,15 +767,6 @@
     'include': '#comments'
   }
   {
-    'captures':
-      '0':
-        'name': 'punctuation.definition.comment.html.js'
-      '2':
-        'name': 'punctuation.definition.comment.html.js'
-    'match': '(<!--|-->)'
-    'name': 'comment.block.html.js'
-  }
-  {
     'match': '(?<!\\.)\\b(class|enum|function|interface)(?!\\s*:)\\b'
     'name': 'storage.type.js'
   }
@@ -1615,9 +1606,16 @@
             'beginCaptures':
               '0':
                 'name': 'punctuation.definition.comment.js'
-            'end': '\\n'
+            'end': '\\n|(?=-->)'
             'name': 'comment.line.double-slash.js'
           }
         ]
+      }
+      {
+        'match': '<!--|-->'
+        'captures':
+          '0':
+            'name': 'punctuation.definition.comment.html.js'
+        'name': 'comment.html.js'
       }
     ]

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -1503,6 +1503,19 @@ describe "Javascript grammar", ->
       expect(tokens[0]).toEqual value: '//', scopes: ['source.js', 'comment.line.double-slash.js', 'punctuation.definition.comment.js']
       expect(tokens[1]).toEqual value: ' comment', scopes: ['source.js', 'comment.line.double-slash.js']
 
+    it "tokenizes HTML-style comments", ->
+      {tokens} = grammar.tokenizeLine('<!-- var x -->')
+      expect(tokens[0]).toEqual value: '<!--', scopes: ['source.js', 'comment.html.js', 'punctuation.definition.comment.html.js']
+      expect(tokens[2]).toEqual value: 'var', scopes: ['source.js', 'storage.type.var.js']
+      expect(tokens[4]).toEqual value: '-->', scopes: ['source.js', 'comment.html.js', 'punctuation.definition.comment.html.js']
+
+    it "prioritizes HTML-style comments when paired with regular line comments", ->
+      {tokens} = grammar.tokenizeLine('//comment --> var x')
+      expect(tokens[0]).toEqual value: '//', scopes: ['source.js', 'comment.line.double-slash.js', 'punctuation.definition.comment.js']
+      expect(tokens[1]).toEqual value: 'comment ', scopes: ['source.js', 'comment.line.double-slash.js']
+      expect(tokens[2]).toEqual value: '-->', scopes: ['source.js', 'comment.html.js', 'punctuation.definition.comment.html.js']
+      expect(tokens[4]).toEqual value: 'var', scopes: ['source.js', 'storage.type.var.js']
+
     it "tokenizes comments inside constant definitions", ->
       {tokens} = grammar.tokenizeLine('const a, // comment')
       expect(tokens[0]).toEqual value: 'const', scopes: ['source.js', 'storage.modifier.js']


### PR DESCRIPTION
`-->` automatically ends a regular `//` comment for HTML interoperability.  For example,
```html
<script type="text/javascript"><!--
       var hello;
//--></script>
```
is valid HTML and JavaScript and ends the `<script>` block correctly.

This does **not** add support for [ES6 HTML-style comments](http://www.ecma-international.org/ecma-262/6.0/#sec-html-like-comments).

Unblocks atom/language-html#90.