### PR TITLE
Add support for ES6 HTML-style comments

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -804,15 +804,6 @@
     'include': '#comments'
   }
   {
-    'captures':
-      '0':
-        'name': 'punctuation.definition.comment.html.js'
-      '2':
-        'name': 'punctuation.definition.comment.html.js'
-    'match': '(<!--|-->)'
-    'name': 'comment.block.html.js'
-  }
-  {
     'match': '(?<!\\.)\\b(class|enum|function|interface)(?!\\s*:)\\b'
     'name': 'storage.type.js'
   }
@@ -1629,7 +1620,7 @@
             'include': '#docblock'
           }
         ]
-        'end': '\\*/'
+        'end': '\\*/|(?=</script>)' # Unfortunately, we don't know when we're embedded, so this is as good as it gets
         'name': 'comment.block.documentation.js'
       }
       {
@@ -1637,7 +1628,7 @@
         'captures':
           '0':
             'name': 'punctuation.definition.comment.js'
-        'end': '\\*/'
+        'end': '\\*/|(?=</script>)' # Unfortunately, we don't know when we're embedded, so this is as good as it gets
         'name': 'comment.block.js'
       }
       {
@@ -1652,8 +1643,42 @@
             'beginCaptures':
               '0':
                 'name': 'punctuation.definition.comment.js'
-            'end': '\\n'
+            'end': '$|(?=</script>)' # Unfortunately, we don't know when we're embedded, so this is as good as it gets
             'name': 'comment.line.double-slash.js'
+          }
+        ]
+      }
+      {
+        'begin': '(^[ \\t]+)?(?=<!--)'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.whitespace.comment.leading.js'
+        'end': '(?!\\G)'
+        'patterns': [
+          {
+            'begin': '<!--'
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.definition.comment.html.js'
+            'end': '$|(?=</script>)' # Unfortunately, we don't know when we're embedded, so this is as good as it gets
+            'name': 'comment.line.html.js'
+          }
+        ]
+      }
+      {
+        'begin': '(^[ \\t]+)?(?=-->)'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.whitespace.comment.leading.js'
+        'end': '(?!\\G)'
+        'patterns': [
+          {
+            'begin': '-->'
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.definition.comment.html.js'
+            'end': '$|(?=</script>)' # Unfortunately, we don't know when we're embedded, so this is as good as it gets
+            'name': 'comment.line.html.js'
           }
         ]
       }

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -1563,6 +1563,39 @@ describe "Javascript grammar", ->
       expect(tokens[7]).toEqual value: ', p2 ', scopes: ['source.js', 'meta.function.js', 'meta.parameters.js', 'comment.block.js']
       expect(tokens[8]).toEqual value: '*/', scopes: ['source.js', 'meta.function.js', 'meta.parameters.js', 'comment.block.js', 'punctuation.definition.comment.js']
 
+    it "tokenizes HTML-style comments correctly", ->
+      {tokens} = grammar.tokenizeLine '<!-- comment'
+      expect(tokens[0]).toEqual value: '<!--', scopes: ['source.js', 'comment.line.html.js', 'punctuation.definition.comment.html.js']
+      expect(tokens[1]).toEqual value: ' comment', scopes: ['source.js', 'comment.line.html.js']
+
+      {tokens} = grammar.tokenizeLine '--> comment'
+      expect(tokens[0]).toEqual value: '-->', scopes: ['source.js', 'comment.line.html.js', 'punctuation.definition.comment.html.js']
+      expect(tokens[1]).toEqual value: ' comment', scopes: ['source.js', 'comment.line.html.js']
+
+    it "stops comments when a </script> tag is encountered", ->
+      # HTML doesn't count comments if they're followed by a </script> tag.  Unfortunately we have
+      # no idea if we're embedded or not, so we err on the side of caution and always assume that we are :/
+
+      {tokens} = grammar.tokenizeLine '/* </script>'
+      expect(tokens[0]).toEqual value: '/*', scopes: ['source.js', 'comment.block.js', 'punctuation.definition.comment.js']
+      expect(tokens[1]).not.toEqual value: ' </script>', scopes: ['source.js', 'comment.block.js']
+
+      {tokens} = grammar.tokenizeLine '/** </script>'
+      expect(tokens[0]).toEqual value: '/**', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.definition.comment.js']
+      expect(tokens[1]).not.toEqual value: ' </script>', scopes: ['source.js', 'comment.block.documentation.js']
+
+      {tokens} = grammar.tokenizeLine '// </script>'
+      expect(tokens[0]).toEqual value: '//', scopes: ['source.js', 'comment.line.double-slash.js', 'punctuation.definition.comment.js']
+      expect(tokens[1]).not.toEqual value: ' </script>', scopes: ['source.js', 'comment.line.double-slash.js']
+
+      {tokens} = grammar.tokenizeLine '<!-- </script>'
+      expect(tokens[0]).toEqual value: '<!--', scopes: ['source.js', 'comment.line.html.js', 'punctuation.definition.comment.html.js']
+      expect(tokens[1]).not.toEqual value: ' </script>', scopes: ['source.js', 'comment.line.html.js']
+
+      {tokens} = grammar.tokenizeLine '--> </script>'
+      expect(tokens[0]).toEqual value: '-->', scopes: ['source.js', 'comment.line.html.js', 'punctuation.definition.comment.html.js']
+      expect(tokens[1]).not.toEqual value: ' </script>', scopes: ['source.js', 'comment.line.html.js']
+
   describe "console", ->
     it "tokenizes the console keyword", ->
       {tokens} = grammar.tokenizeLine('console;')


### PR DESCRIPTION
Also end comments when a `</script>` tag is encountered.  This is because HTML and JavaScript can intelligently detect when to break out of the comment and end the script block.  Unfortunately, since we're using a 100% regex-based parser, there's really not much we can do to detect if we're embedded (writing this just now gave me an idea though...will look into it later).  So for now we just be as conservative as possible.

Unblocks atom/language-html#90