### PR TITLE
Style `arguments` like `this`, style superclass name distinctly

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -275,7 +275,7 @@
     'name': 'meta.export.js'
   }
   {
-    'match': '(?<!\\.)\\b(super|this)(?!\\s*:)\\b|(?<=\\?)(?:\\s*)(super|this)(?=\\s*:)'
+    'match': '(?<!\\.)\\b(super|this|arguments)(?!\\s*:)\\b|(?<=\\?)(?:\\s*)(super|this|arguments)(?=\\s*:)'
     'captures':
       '1':
         'name': 'variable.language.js'
@@ -695,13 +695,13 @@
       '2':
         'name': 'storage.modifier.js'
       '3':
-        'name': 'entity.name.type.class.js'
+        'name': 'entity.other.inherited-class.js'
       '4':
         'name': 'entity.name.type.class.js'
       '5':
         'name': 'storage.modifier.js'
       '6':
-        'name': 'entity.name.type.class.js'
+        'name': 'entity.other.inherited-class.js'
     'name': 'meta.class.js'
   }
   {

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -629,25 +629,25 @@ describe "Javascript grammar", ->
       expect(tokens[0]).toEqual value: 'class', scopes: ['source.js', 'meta.class.js', 'storage.type.class.js']
       expect(tokens[2]).toEqual value: 'MyClass', scopes: ['source.js', 'meta.class.js', 'entity.name.type.class.js']
       expect(tokens[4]).toEqual value: 'extends', scopes: ['source.js', 'meta.class.js', 'storage.modifier.js']
-      expect(tokens[6]).toEqual value: 'SomeClass', scopes: ['source.js', 'meta.class.js', 'entity.name.type.class.js']
+      expect(tokens[6]).toEqual value: 'SomeClass', scopes: ['source.js', 'meta.class.js', 'entity.other.inherited-class.js']
 
       {tokens} = grammar.tokenizeLine('class MyClass extends $abc$')
-      expect(tokens[6]).toEqual value: '$abc$', scopes: ['source.js', 'meta.class.js', 'entity.name.type.class.js']
+      expect(tokens[6]).toEqual value: '$abc$', scopes: ['source.js', 'meta.class.js', 'entity.other.inherited-class.js']
 
       {tokens} = grammar.tokenizeLine('class MyClass extends $$')
-      expect(tokens[6]).toEqual value: '$$', scopes: ['source.js', 'meta.class.js', 'entity.name.type.class.js']
+      expect(tokens[6]).toEqual value: '$$', scopes: ['source.js', 'meta.class.js', 'entity.other.inherited-class.js']
 
     it "tokenizes anonymous class", ->
       {tokens} = grammar.tokenizeLine('class extends SomeClass')
       expect(tokens[0]).toEqual value: 'class', scopes: ['source.js', 'meta.class.js', 'storage.type.class.js']
       expect(tokens[2]).toEqual value: 'extends', scopes: ['source.js', 'meta.class.js', 'storage.modifier.js']
-      expect(tokens[4]).toEqual value: 'SomeClass', scopes: ['source.js', 'meta.class.js', 'entity.name.type.class.js']
+      expect(tokens[4]).toEqual value: 'SomeClass', scopes: ['source.js', 'meta.class.js', 'entity.other.inherited-class.js']
 
       {tokens} = grammar.tokenizeLine('class extends $abc$')
-      expect(tokens[4]).toEqual value: '$abc$', scopes: ['source.js', 'meta.class.js', 'entity.name.type.class.js']
+      expect(tokens[4]).toEqual value: '$abc$', scopes: ['source.js', 'meta.class.js', 'entity.other.inherited-class.js']
 
       {tokens} = grammar.tokenizeLine('class extends $$')
-      expect(tokens[4]).toEqual value: '$$', scopes: ['source.js', 'meta.class.js', 'entity.name.type.class.js']
+      expect(tokens[4]).toEqual value: '$$', scopes: ['source.js', 'meta.class.js', 'entity.other.inherited-class.js']
 
   describe "ES6 import", ->
     it "tokenizes import", ->
@@ -1187,6 +1187,16 @@ describe "Javascript grammar", ->
     it "tokenizes 'super'", ->
       {tokens} = grammar.tokenizeLine('super')
       expect(tokens[0]).toEqual value: 'super', scopes: ['source.js', 'variable.language.js']
+
+    it "tokenizes 'arguments'", ->
+      {tokens} = grammar.tokenizeLine('arguments')
+      expect(tokens[0]).toEqual value: 'arguments', scopes: ['source.js', 'variable.language.js']
+
+      {tokens} = grammar.tokenizeLine('arguments[0]')
+      expect(tokens[0]).toEqual value: 'arguments', scopes: ['source.js', 'variable.language.js']
+
+      {tokens} = grammar.tokenizeLine('arguments.length')
+      expect(tokens[0]).toEqual value: 'arguments', scopes: ['source.js', 'variable.language.js']
 
     it "tokenizes illegal identifiers", ->
       {tokens} = grammar.tokenizeLine('0illegal')


### PR DESCRIPTION
1. `arguments` now uses `variable.language` like `this` and `super`, since it's scoped identically, and it's normally treated as a keyword in practice, not a traditional variable (even though it's technically a valid identifier).
2. The `extends` clause of classes now uses `entity.other.inherited-class`, like in the language packages for many other OO languages (e.g. Java, Scala, Ruby).