### PR TITLE
Add missing JSDoc tags used by Closure Compiler

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1601,7 +1601,7 @@
   'docblock':
     'patterns': [
       {
-        'match': '(?<!\\w)@(abstract|access|alias|augments|author|async|attribute|arg|argument|beta|borrows|bubbes|callback|class|classdesc|config|const|constant|constructs|constructor|copyright|chainable|default|defaultvalue|deprecated|desc|description|enum|emits|event|example|exports|external|extends|extension|extensionfor|extension_for|for|file|fileoverview|fires|final|function|global|host|ignore|implements|inheritdoc|inner|instance|interface|kind|lends|license|listens|main|member|memberof|method|mixex|mixin(?:s|)|module|name|namespace|override|overview|param|private|prop|property|protected|public|readonly|readOnly|requires|required|return|returns|see|since|static|summary|submodule|this|throws|todo|tutorial|type|typedef|var|variation|version|virtual|uses|writeOnce)\\b'
+        'match': '(?<!\\w)@(abstract|access|alias|arg|argument|async|attribute|augments|author|beta|borrows|bubbes|callback|chainable|class|classdesc|code|config|const|constant|constructor|constructs|copyright|default|defaultvalue|define|deprecated|desc|description|dict|emits|enum|event|example|exports?|extends|extension|extension_for|extensionfor|external|file|fileoverview|final|fires|for|function|global|host|ignore|implements|inherit[Dd]oc|inner|instance|interface|kind|lends|license|listens|main|member|memberof|method|mixex|mixins?|module|name|namespace|nocollapse|nosideeffects|override|overview|package|param|preserve|private|prop|property|protected|public|read[Oo]nly|record|require[ds]|returns?|see|since|static|struct|submodule|summary|template|this|throws|todo|tutorial|type|typedef|unrestricted|uses|var|variation|version|virtual|writeOnce)\\b'
         'name': 'storage.type.class.jsdoc'
       }
       {


### PR DESCRIPTION
Add the missing [JSDoc tags used by Closure Compiler](https://developers.google.com/closure/compiler/docs/js-for-compiler) that were not already in the list. This PR ensures that all JSDoc tags in the below sample are properly highlighted.

```js
/**
 * A reference to the class {@code Class} followed by the JSDoc
 * tags understood by Closure Compiler.
 *
 * @abstract
 * @const
 * @constructor
 * @define
 * @deprecated
 * @dict
 * @enum
 * @export (currently only @exports supported)
 * @extends
 * @final
 * @implements
 * @inheritDoc (currently only @inheritdoc supported)
 * @interface
 * @lends
 * @license / @preserve
 * @nocollapse
 * @nosideeffects
 * @override
 * @package
 * @param
 * @private
 * @protected
 * @record
 * @return
 * @struct
 * @template
 * @this
 * @throws
 * @type
 * @typedef
 * @unrestricted
 */
```
