### PR TITLE
🐛  Allow 'from' as identifier

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -891,7 +891,7 @@
     'name': 'meta.control.yield.js'
   }
   {
-    'match': '(?<!\\.)\\b(await|break|case|catch|continue|do|else|finally|for|if|import|from|package|return|switch|throw|try|while|with)(?!\\s*:)\\b'
+    'match': '(?<!\\.)\\b(await|break|case|catch|continue|do|else|finally|for|if|import|package|return|switch|throw|try|while|with)(?!\\s*:)\\b'
     'name': 'keyword.control.js'
   }
   {


### PR DESCRIPTION
`from` is not a reserved word
```js
from = 123 // shouldn't be highlighted as a keyword
abc = 123
```

Fixes #377