### PR TITLE
Allow multiple spaces in JSDoc tags

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1605,7 +1605,7 @@
         'name': 'storage.type.class.jsdoc'
       }
       {
-        'match': '({\\b(?:[a-zA-Z_$][a-zA-Z_$0-9]*)\\b})\\s\\b([a-zA-Z_$][a-zA-Z_$0-9]*)\\b\\s*((?:(?!\\*\\/).)*)'
+        'match': '({\\b(?:[a-zA-Z_$][a-zA-Z_$0-9]*)\\b})\\s+\\b([a-zA-Z_$][a-zA-Z_$0-9]*)\\b\\s*((?:(?!\\*\\/).)*)'
         'captures':
             0:
               'name': 'other.meta.jsdoc'


### PR DESCRIPTION
... this is driving me nuts.

<img src="https://cloud.githubusercontent.com/assets/2346707/17464087/97f2e8d8-5d19-11e6-9ea9-2e771af22bc3.gif" width="493" alt="Figure 1" />
