### PR TITLE
Extend list of DOM methods

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1442,7 +1442,7 @@
                 'match': '''(?x)
                   \\b(acceptNode|add|addEventListener|addTextTrack|adoptNode|after|animate|append|
                   appendChild|appendData|before|blur|canPlayType|captureStream|
-                  caretPositionFromPoint|caretRangeFromPoint|checkValidity|clear|clear|click|
+                  caretPositionFromPoint|caretRangeFromPoint|checkValidity|clear|click|
                   cloneContents|cloneNode|cloneRange|close|closest|collapse|
                   compareBoundaryPoints|compareDocumentPosition|comparePoint|contains|
                   convertPointFromNode|convertQuadFromNode|convertRectFromNode|createAttribute|

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1427,13 +1427,11 @@
                   createEventObject|to(GMTString|UTCString|String|Source|UpperCase|LowerCase|LocaleString)|
                   test|taint|taintEnabled|indexOf|italics|disableExternalCapture|dump|detachEvent|unshift|
                   untaint|unwatch|updateCommands|join|javaEnabled|pop|push|plugins.refresh|paddings|parse|
-                  print|prompt|preference|enableExternalCapture|elementFromPoint|exec|execScript|
-                  execCommand|valueOf|UTC|queryCommandState|queryCommandIndeterm|queryCommandEnabled|
-                  queryCommandValue|find|file|fileModifiedDate|fileSize|fileCreatedDate|fileUpdatedDate|
-                  fixed|fontsize|fontcolor|forward|fromCharCode|watch|link|load|lastIndexOf|
-                  anchor|attachEvent|atob|apply|alert|abort|routeEvents|
-                  resize|resizeBy|resizeTo|recalc|returnValue|replace|reverse|reload|releaseCapture|
-                  releaseEvents|go|get(Milliseconds|Seconds|Minutes|Hours|Month|Day|Year|FullYear|
+                  print|prompt|preference|enableExternalCapture|exec|execScript|valueOf|UTC|find|file|
+                  fileModifiedDate|fileSize|fileCreatedDate|fileUpdatedDate|fixed|fontsize|fontcolor|
+                  forward|fromCharCode|watch|link|load|lastIndexOf|anchor|attachEvent|atob|apply|alert|
+                  abort|routeEvents|resize|resizeBy|resizeTo|recalc|returnValue|replace|reverse|reload|
+                  releaseCapture|releaseEvents|go|get(Milliseconds|Seconds|Minutes|Hours|Month|Day|Year|FullYear|
                   Time|Date|TimezoneOffset|UTC(Milliseconds|Seconds|Minutes|Hours|Day|Month|FullYear|Date)|
                   Attention|Selection|ResponseHeader|AllResponseHeaders)|moveBy|moveBelow|moveTo|
                   moveToAbsolute|moveAbove|mergeAttributes|match|margins|btoa|big|bold|borderWidths|blink|back)\\b
@@ -1442,15 +1440,49 @@
               }
               {
                 'match': '''(?x)
-                  \\b(substringData|submit|splitText|setNamedItem|setAttribute|setAttributeNode|select|
-                  hasChildNodes|hasFeature|namedItem|click|close|cloneNode|createComment|createCDATASection|
-                  createCaption|createTHead|createTextNode|createTFoot|createDocumentFragment|
-                  createProcessingInstruction|createEntityReference|createElement|createAttribute|
-                  tabIndex|insertRow|insertBefore|insertCell|insertData|item|open|deleteRow|deleteCell|
-                  deleteCaption|deleteTHead|deleteTFoot|deleteData|focus|write|writeln|add|appendChild|
-                  appendData|reset|replaceChild|replaceData|move|moveNamedItem|moveChild|moveAttribute|
-                  moveAttributeNode|getNamedItem|getElementsByName|getElementsByTagName|getElementById|
-                  getAttribute|getAttributeNode|blur)\\b
+                  \\b(acceptNode|add|addEventListener|addTextTrack|adoptNode|after|animate|append|
+                  appendChild|appendData|before|blur|canPlayType|captureStream|
+                  caretPositionFromPoint|caretRangeFromPoint|checkValidity|clear|clear|click|
+                  cloneContents|cloneNode|cloneRange|close|closest|collapse|
+                  compareBoundaryPoints|compareDocumentPosition|comparePoint|contains|
+                  convertPointFromNode|convertQuadFromNode|convertRectFromNode|createAttribute|
+                  createAttributeNS|createCaption|createCDATASection|createComment|
+                  createContextualFragment|createDocument|createDocumentFragment|
+                  createDocumentType|createElement|createElementNS|createEntityReference|
+                  createEvent|createExpression|createHTMLDocument|createNodeIterator|
+                  createNSResolver|createProcessingInstruction|createRange|createShadowRoot|
+                  createTBody|createTextNode|createTFoot|createTHead|createTreeWalker|delete|
+                  deleteCaption|deleteCell|deleteContents|deleteData|deleteRow|deleteTFoot|
+                  deleteTHead|detach|disconnect|dispatchEvent|elementFromPoint|elementsFromPoint|
+                  enableStyleSheetsForSet|entries|evaluate|execCommand|exitFullscreen|
+                  exitPointerLock|expand|extractContents|fastSeek|firstChild|focus|forEach|get|
+                  getAll|getAnimations|getAttribute|getAttributeNames|getAttributeNode|
+                  getAttributeNodeNS|getAttributeNS|getBoundingClientRect|getBoxQuads|
+                  getClientRects|getContext|getDestinationInsertionPoints|getElementById|
+                  getElementsByClassName|getElementsByName|getElementsByTagName|
+                  getElementsByTagNameNS|getItem|getNamedItem|getSelection|getStartDate|
+                  getVideoPlaybackQuality|has|hasAttribute|hasAttributeNS|hasAttributes|
+                  hasChildNodes|hasFeature|hasFocus|importNode|initEvent|insertAdjacentElement|
+                  insertAdjacentHTML|insertAdjacentText|insertBefore|insertCell|insertData|
+                  insertNode|insertRow|intersectsNode|isDefaultNamespace|isEqualNode|
+                  isPointInRange|isSameNode|item|key|keys|lastChild|load|lookupNamespaceURI|
+                  lookupPrefix|matches|move|moveAttribute|moveAttributeNode|moveChild|
+                  moveNamedItem|namedItem|nextNode|nextSibling|normalize|observe|open|
+                  parentNode|pause|play|postMessage|prepend|preventDefault|previousNode|
+                  previousSibling|probablySupportsContext|queryCommandEnabled|
+                  queryCommandIndeterm|queryCommandState|queryCommandSupported|queryCommandValue|
+                  querySelector|querySelectorAll|registerContentHandler|registerElement|
+                  registerProtocolHandler|releaseCapture|releaseEvents|remove|removeAttribute|
+                  removeAttributeNode|removeAttributeNS|removeChild|removeEventListener|
+                  removeItem|replace|replaceChild|replaceData|replaceWith|reportValidity|
+                  requestFullscreen|requestPointerLock|reset|scroll|scrollBy|scrollIntoView|
+                  scrollTo|seekToNextFrame|select|selectNode|selectNodeContents|set|setAttribute|
+                  setAttributeNode|setAttributeNodeNS|setAttributeNS|setCapture|
+                  setCustomValidity|setEnd|setEndAfter|setEndBefore|setItem|setNamedItem|
+                  setRangeText|setSelectionRange|setSinkId|setStart|setStartAfter|setStartBefore|
+                  slice|splitText|stepDown|stepUp|stopImmediatePropagation|stopPropagation|
+                  submit|substringData|supports|surroundContents|takeRecords|terminate|toBlob|
+                  toDataURL|toggle|toString|values|write|writeln)\\b
                 '''
                 'name': 'support.function.dom.js'
               }


### PR DESCRIPTION
This pull request extends the list of methods recognized as being part of the DOM. The original list was very incomplete and led to peculiar behaviour such as classList.add() and classList.remove() being coloured differently.

These additions were collected by iterating through several common DOM interfaces, mainly in Firefox and Chrome. For practical reasons it is by no means complete, but I believe it covers those which are most-used. Intentional omissions include prefixed properties and non-standard properties with little adoption. I also removed a couple of overlapping properties from the support.function.js regex.