### PR TITLE
Fix missing highlighting in case statements

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -275,11 +275,19 @@
     'name': 'meta.export.js'
   }
   {
-    'match': '(?<!\\.)\\b(super|this|arguments)(?!\\s*:)\\b|(?<=\\?)(?:\\s*)(super|this|arguments)(?=\\s*:)'
+    'match': '(?x)
+      (?<!\\.)\\b(super|this|arguments)(?!\\s*:)\\b
+      |
+      (?<=\\?)\\s*(super|this|arguments)(?=\\s*:)
+      |
+      (?<=[\\s}:;]case|^case)\\s+(super|this|arguments)(?=\\s*:)
+    '
     'captures':
       '1':
         'name': 'variable.language.js'
       '2':
+        'name': 'variable.language.js'
+      '3':
         'name': 'variable.language.js'
   }
   {
@@ -907,27 +915,51 @@
     'name': 'keyword.operator.spread.js'
   }
   {
-    'match': '(?<!\\.)\\b(true|false)(?!\\s*:)\\b|(?<=\\?)(?:\\s*)(true|false)(?=\\s*:)'
+    'match': '(?x)
+      (?<!\\.)\\b(true|false)(?!\\s*:)\\b
+      |
+      (?<=\\?)\\s*(true|false)(?=\\s*:)
+      |
+      (?<=[\\s}:;]case|^case)\\s+(true|false)(?=\\s*:)
+    '
     'captures':
       '1':
         'name': 'constant.language.boolean.$1.js'
       '2':
         'name': 'constant.language.boolean.$2.js'
+      '3':
+        'name': 'constant.language.boolean.$3.js'
   }
   {
-    'match': '(?<!\\.)\\b(null)(?!\\s*:)\\b|(?<=\\?)(?:\\s*)(null)(?=\\s*:)'
+    'match': '(?x)
+      (?<!\\.)\\b(null)(?!\\s*:)\\b
+      |
+      (?<=\\?)\\s*(null)(?=\\s*:)
+      |
+      (?<=[\\s}:;]case|^case)\\s+(null)(?=\\s*:)
+    '
     'captures':
       '1':
         'name': 'constant.language.null.js'
       '2':
         'name': 'constant.language.null.js'
+      '3':
+        'name': 'constant.language.null.js'
   }
   {
-    'match': '(?<!\\.)\\b(debugger)(?!\\s*:)\\b|(?<=\\?)(?:\\s*)(debugger)(?=\\s*:)'
+    'match': '(?x)
+      (?<!\\.)\\b(debugger)(?!\\s*:)\\b
+      |
+      (?<=\\?)\\s*(debugger)(?=\\s*:)
+      |
+      (?<=[\\s}:;]case|^case)\\s+(debugger)(?=\\s*:)
+    '
     'captures':
       '1':
         'name': 'keyword.other.js'
       '2':
+        'name': 'keyword.other.js'
+      '3':
         'name': 'keyword.other.js'
   }
   {
@@ -955,11 +987,19 @@
     'name': 'support.constant.dom.js'
   }
   {
-    'match': '(?<!\\.)\\b(module|exports|__filename|__dirname|global|process)(?!\\s*:)\\b|(?<=\\?)(?:\\s*)(module|exports|__filename|__dirname|global|process)(?=\\s*:)'
+    'match': '(?x)
+      (?<!\\.)\\b(module|exports|__filename|__dirname|global|process)(?!\\s*:)\\b
+      |
+      (?<=\\?)\\s*(module|exports|__filename|__dirname|global|process)(?=\\s*:)
+      |
+      (?<=[\\s}:;]case|^case)\\s+(module|exports|__filename|__dirname|global|process)(?=\\s*:)
+    '
     'captures':
       '1':
         'name': 'support.variable.js'
       '2':
+        'name': 'support.variable.js'
+      '3':
         'name': 'support.variable.js'
   }
   {

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -275,13 +275,13 @@
     'name': 'meta.export.js'
   }
   {
-    'match': '(?x)
+    'match': '''(?x)
       (?<!\\.)\\b(super|this|arguments)(?!\\s*:)\\b
       |
       (?<=\\?)\\s*(super|this|arguments)(?=\\s*:)
       |
       (?<=[\\s}:;]case|^case)\\s+(super|this|arguments)(?=\\s*:)
-    '
+    '''
     'captures':
       '1':
         'name': 'variable.language.js'
@@ -915,13 +915,13 @@
     'name': 'keyword.operator.spread.js'
   }
   {
-    'match': '(?x)
+    'match': '''(?x)
       (?<!\\.)\\b(true|false)(?!\\s*:)\\b
       |
       (?<=\\?)\\s*(true|false)(?=\\s*:)
       |
       (?<=[\\s}:;]case|^case)\\s+(true|false)(?=\\s*:)
-    '
+    '''
     'captures':
       '1':
         'name': 'constant.language.boolean.$1.js'
@@ -931,13 +931,13 @@
         'name': 'constant.language.boolean.$3.js'
   }
   {
-    'match': '(?x)
+    'match': '''(?x)
       (?<!\\.)\\b(null)(?!\\s*:)\\b
       |
       (?<=\\?)\\s*(null)(?=\\s*:)
       |
       (?<=[\\s}:;]case|^case)\\s+(null)(?=\\s*:)
-    '
+    '''
     'captures':
       '1':
         'name': 'constant.language.null.js'
@@ -947,13 +947,13 @@
         'name': 'constant.language.null.js'
   }
   {
-    'match': '(?x)
+    'match': '''(?x)
       (?<!\\.)\\b(debugger)(?!\\s*:)\\b
       |
       (?<=\\?)\\s*(debugger)(?=\\s*:)
       |
       (?<=[\\s}:;]case|^case)\\s+(debugger)(?=\\s*:)
-    '
+    '''
     'captures':
       '1':
         'name': 'keyword.other.js'
@@ -987,13 +987,13 @@
     'name': 'support.constant.dom.js'
   }
   {
-    'match': '(?x)
+    'match': '''(?x)
       (?<!\\.)\\b(module|exports|__filename|__dirname|global|process)(?!\\s*:)\\b
       |
       (?<=\\?)\\s*(module|exports|__filename|__dirname|global|process)(?=\\s*:)
       |
       (?<=[\\s}:;]case|^case)\\s+(module|exports|__filename|__dirname|global|process)(?=\\s*:)
-    '
+    '''
     'captures':
       '1':
         'name': 'support.variable.js'

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -86,6 +86,12 @@ describe "Javascript grammar", ->
           expect(tokens[4]).toEqual value: ' ', scopes: ['source.js']
           expect(tokens[5]).toEqual value: keyword, scopes: ['source.js', scope]
 
+        it "tokenises `#{keyword}` in case statements", ->
+          {tokens} = grammar.tokenizeLine("case #{keyword}:")
+          expect(tokens[0]).toEqual value: 'case', scopes: ['source.js', 'keyword.control.js']
+          expect(tokens[2]).toEqual value: keyword, scopes: ['source.js', scope]
+          expect(tokens[3]).toEqual value: ':', scopes: ['source.js', 'keyword.operator.js']
+
   describe "built-in globals", ->
     it "tokenizes built-in classes", ->
       {tokens} = grammar.tokenizeLine('window')


### PR DESCRIPTION
Some values don't receive their usual highlighting when used inside a case statement:

<img src="https://cloud.githubusercontent.com/assets/2346707/17814408/1f402c30-6673-11e6-8254-4da1ef6fa633.png" width="200" alt="Figure 1" />

Not all of these statements are valid JavaScript (e.g., `case debugger:`), but authors should probably be reminded of a keyword's significance through highlighting.