### PR TITLE
Add improved JSDoc support for @returns

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1677,16 +1677,38 @@
         'name': 'storage.type.class.jsdoc'
       }
       {
-        'match': '({(?:\\*|(?:\\?|\\!|\\.{3})?[a-zA-Z_$][\\w$]*(?:\\.[a-zA-Z_$][\\w$]*)*(?:\\[\\])?=?)})\\s+(\\[(?:[a-zA-Z_$]+(?:=[\\w][\\s\\w$]*)?)\\]|(?:[a-zA-Z_$][\\w$]*(?:\\.[a-zA-Z_$][\\w$]*)*))\\s*((?:(?!\\*\\/).)*)'
+        'match': '''(?x)
+          ({(?:\\*|(?:\\?|\\!|\\.{3})?[a-zA-Z_$][\\w$]*(?:\\.[a-zA-Z_$][\\w$]*)*(?:\\[\\])?=?)})
+          \\s+
+          (\\[(?:[a-zA-Z_$]+(?:=[\\w][\\s\\w$]*)?)\\]|(?:[a-zA-Z_$][\\w$]*(?:\\.[a-zA-Z_$][\\w$]*)*))
+          \\s+
+          ((?:(?!\\*\\/).)*)
+        '''
         'captures':
-            0:
-              'name': 'other.meta.jsdoc'
-            1:
-              'name': 'entity.name.type.instance.jsdoc'
-            2:
-              'name': 'variable.other.jsdoc'
-            3:
-              'name': 'other.description.jsdoc'
+          '0':
+            'name': 'other.meta.jsdoc'
+          '1':
+            'name': 'entity.name.type.instance.jsdoc'
+          '2':
+            'name': 'variable.other.jsdoc'
+          '3':
+            'name': 'other.description.jsdoc'
+      }
+      {
+        'match': '''(?x)
+          (?:(?<=@returns)|(?<=@return))
+          \\s+
+          ({(?:\\*|(?:\\?|\\!|\\.{3})?[a-zA-Z_$][\\w$]*(?:\\.[a-zA-Z_$][\\w$]*)*(?:\\[\\])?=?)})
+          \\s+
+          ((?:(?!\\*\\/).)*)
+        '''
+        'captures':
+          '0':
+            'name': 'other.meta.jsdoc'
+          '1':
+            'name': 'entity.name.type.instance.jsdoc'
+          '2':
+            'name': 'other.description.jsdoc'
       }
     ]
   'comments':

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -1573,6 +1573,20 @@ describe "Javascript grammar", ->
       expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
       expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
+      {tokens} = grammar.tokenizeLine('/** @return {object} this is the description */')
+      expect(tokens[4]).toEqual value: '{object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @return {object} */')
+      expect(tokens[4]).toEqual value: '{object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @returns {object} this is the description */')
+      expect(tokens[4]).toEqual value: '{object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @returns {object} */')
+      expect(tokens[4]).toEqual value: '{object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+
     it "tokenizes // comments", ->
       {tokens} = grammar.tokenizeLine('// comment')
       expect(tokens[0]).toEqual value: '//', scopes: ['source.js', 'comment.line.double-slash.js', 'punctuation.definition.comment.js']


### PR DESCRIPTION
This PR adds improved support for JSDoc highlighting of `@return` and `@returns`. Currently the first word of a description will incorrectly take on the scope of a variable (an element that the `@returns` doesn't have http://usejsdoc.org/tags-returns.html)

Before:
![screen shot 2016-08-23 at 00 22 15](https://cloud.githubusercontent.com/assets/2854338/17875127/bc753396-68c7-11e6-8413-2cd8941e9fa2.png)

After:
![screen shot 2016-08-23 at 00 22 34](https://cloud.githubusercontent.com/assets/2854338/17875132/c440766c-68c7-11e6-865b-780d3ad67fbb.png)

Also took the opportunity to tidy up the JSDoc code a bit.