### PR TITLE
Fix function keyword as property name

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -297,7 +297,7 @@
   {
     # [async] function [name](params)
     # function* name(params) – generator function declaration
-    'begin': '(?=(\\basync\\b\\s*)?\\bfunction\\b(?!:))'
+    'begin': '(?=(\\basync\\b\\s*)?\\bfunction\\b(?!\\s*:))'
     'end': '(?<=})'
     'patterns': [
       {
@@ -591,7 +591,7 @@
       (?<=})|
       ((?!
         \\s*{|
-        \\G[\\w$]+:|
+        \\G[\\w$]+\\s*:|
         \\s*/\\*|\\s*//
       )(?=\\s*\\S))
     '''

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -297,7 +297,7 @@
   {
     # [async] function [name](params)
     # function* name(params) – generator function declaration
-    'begin': '(?=(\\basync\\b\\s*)?\\bfunction\\b)'
+    'begin': '(?=(\\basync\\b\\s*)?\\bfunction\\b(?!:))'
     'end': '(?<=})'
     'patterns': [
       {

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -1084,6 +1084,13 @@ describe "Javascript grammar", ->
       expect(tokens[7]).toEqual value: 'foo', scopes: ['source.js', 'meta.function.json.js', 'entity.name.function.js']
       expect(tokens[8]).toEqual value: '(', scopes: ['source.js', 'meta.function.json.js', 'meta.parameters.js', 'punctuation.definition.parameters.begin.bracket.round.js']
 
+      {tokens} = grammar.tokenizeLine('function: a => a')
+      expect(tokens[0]).toEqual value: 'function', scopes: ['source.js', 'meta.function.arrow.json.js', 'entity.name.function.js']
+      expect(tokens[1]).toEqual value: ':', scopes: ['source.js', 'meta.function.arrow.json.js', 'keyword.operator.assignment.js']
+      expect(tokens[3]).toEqual value: 'a', scopes: ['source.js', 'meta.function.arrow.json.js', 'meta.parameters.js', 'variable.parameter.function.js']
+      expect(tokens[5]).toEqual value: '=>', scopes: ['source.js', 'meta.function.arrow.json.js', 'storage.type.function.arrow.js']
+      expect(tokens[6]).toEqual value: ' a', scopes: ['source.js']
+
     it "tokenizes generator functions", ->
       {tokens} = grammar.tokenizeLine('function* foo(){}')
       expect(tokens[0]).toEqual value: 'function', scopes: ['source.js', 'meta.function.js', 'storage.type.function.js']

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -1091,6 +1091,13 @@ describe "Javascript grammar", ->
       expect(tokens[5]).toEqual value: '=>', scopes: ['source.js', 'meta.function.arrow.json.js', 'storage.type.function.arrow.js']
       expect(tokens[6]).toEqual value: ' a', scopes: ['source.js']
 
+      {tokens} = grammar.tokenizeLine('"func": a => a')
+      expect(tokens[1]).toEqual value: 'func', scopes: ['source.js', 'meta.function.arrow.json.js', 'string.quoted.double.js', 'entity.name.function.js']
+      expect(tokens[3]).toEqual value: ':', scopes: ['source.js', 'meta.function.arrow.json.js', 'keyword.operator.assignment.js']
+      expect(tokens[5]).toEqual value: 'a', scopes: ['source.js', 'meta.function.arrow.json.js', 'meta.parameters.js', 'variable.parameter.function.js']
+      expect(tokens[7]).toEqual value: '=>', scopes: ['source.js', 'meta.function.arrow.json.js', 'storage.type.function.arrow.js']
+      expect(tokens[8]).toEqual value: ' a', scopes: ['source.js']
+
     it "tokenizes generator functions", ->
       {tokens} = grammar.tokenizeLine('function* foo(){}')
       expect(tokens[0]).toEqual value: 'function', scopes: ['source.js', 'meta.function.js', 'storage.type.function.js']

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -1084,12 +1084,12 @@ describe "Javascript grammar", ->
       expect(tokens[7]).toEqual value: 'foo', scopes: ['source.js', 'meta.function.json.js', 'entity.name.function.js']
       expect(tokens[8]).toEqual value: '(', scopes: ['source.js', 'meta.function.json.js', 'meta.parameters.js', 'punctuation.definition.parameters.begin.bracket.round.js']
 
-      {tokens} = grammar.tokenizeLine('function: a => a')
+      {tokens} = grammar.tokenizeLine('function : a => a')
       expect(tokens[0]).toEqual value: 'function', scopes: ['source.js', 'meta.function.arrow.json.js', 'entity.name.function.js']
-      expect(tokens[1]).toEqual value: ':', scopes: ['source.js', 'meta.function.arrow.json.js', 'keyword.operator.assignment.js']
-      expect(tokens[3]).toEqual value: 'a', scopes: ['source.js', 'meta.function.arrow.json.js', 'meta.parameters.js', 'variable.parameter.function.js']
-      expect(tokens[5]).toEqual value: '=>', scopes: ['source.js', 'meta.function.arrow.json.js', 'storage.type.function.arrow.js']
-      expect(tokens[6]).toEqual value: ' a', scopes: ['source.js']
+      expect(tokens[2]).toEqual value: ':', scopes: ['source.js', 'meta.function.arrow.json.js', 'keyword.operator.assignment.js']
+      expect(tokens[4]).toEqual value: 'a', scopes: ['source.js', 'meta.function.arrow.json.js', 'meta.parameters.js', 'variable.parameter.function.js']
+      expect(tokens[6]).toEqual value: '=>', scopes: ['source.js', 'meta.function.arrow.json.js', 'storage.type.function.arrow.js']
+      expect(tokens[7]).toEqual value: ' a', scopes: ['source.js']
 
       {tokens} = grammar.tokenizeLine('"func": a => a')
       expect(tokens[1]).toEqual value: 'func', scopes: ['source.js', 'meta.function.arrow.json.js', 'string.quoted.double.js', 'entity.name.function.js']

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -1098,6 +1098,9 @@ describe "Javascript grammar", ->
       expect(tokens[7]).toEqual value: '=>', scopes: ['source.js', 'meta.function.arrow.json.js', 'storage.type.function.arrow.js']
       expect(tokens[8]).toEqual value: ' a', scopes: ['source.js']
 
+      {tokens} = grammar.tokenizeLine('"func" : a => a')
+      expect(tokens[8]).toEqual value: '=>', scopes: ['source.js', 'meta.function.arrow.json.js', 'storage.type.function.arrow.js']
+
     it "tokenizes generator functions", ->
       {tokens} = grammar.tokenizeLine('function* foo(){}')
       expect(tokens[0]).toEqual value: 'function', scopes: ['source.js', 'meta.function.js', 'storage.type.function.js']


### PR DESCRIPTION
[#334 (comment)](https://github.com/atom/language-javascript/issues/334#issuecomment-219531841)

```js
// highlights the contents of the string correctly as a string:
{ func: 'function foo() { return "foo"; }' };
"things are ok";

// now it thinks the string contents are actually a function definition:
{ function: 'function foo() { return "foo"; }' };
"not ok... :("
```

Fixes:
```js
foo: a => a
foo : a => a // bug
```