### PR TITLE
Add \t \r \n \v & \f to RegEx character-class scope

### DIFF
--- a/grammars/regular expressions (javascript).cson
+++ b/grammars/regular expressions (javascript).cson
@@ -10,7 +10,7 @@
   'regex-character-class':
     'patterns': [
       {
-        'match': '\\\\[wWsSdD]|\\.'
+        'match': '\\\\[wWsSdDtrnvf]|\\.'
         'name': 'constant.character.character-class.regexp'
       }
       {


### PR DESCRIPTION
These are also character classes:
- \t (horizontal tab)
- \r (carriage return)
- \n (linefeed)
- \v (vertical tab)
- \f (form-feed)

See: [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#Special_characters_meaning_in_regular_expressions)