### PR TITLE
Improve JSDoc support for optional and default values

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1830,6 +1830,7 @@
           \\s+
           (
             \\[                                          # [foo] optional parameter
+              \\s*
               (?:
                 [a-zA-Z_$][\\w$]*
                 (?:
@@ -1837,10 +1838,12 @@
                   [a-zA-Z_$][\\w$]*
                 )*
                 (?:
+                  \\s*
                   =                                      # [foo=bar] Default parameter value
                   [\\s\\w$]*
                 )?
               )
+              \\s*
             \\] |
             (?:
               [a-zA-Z_$][\\w$]*

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1840,7 +1840,8 @@
                 (?:
                   \\s*
                   =                                      # [foo=bar] Default parameter value
-                  [\\s\\w$]*
+                  \\s*
+                  [\\w$\\s]*
                 )?
               )
               \\s*

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1830,7 +1830,17 @@
           \\s+
           (
             \\[                                          # [foo] optional parameter
-              (?:[a-zA-Z_$]+(?:=[\\w][\\s\\w$]*)?)
+              (?:
+                [a-zA-Z_$][\\w$]*
+                (?:
+                  \\.                                    # Foo.Bar namespaced parameter
+                  [a-zA-Z_$][\\w$]*
+                )*
+                (?:
+                  =                                      # [foo=bar] Default parameter value
+                  [\\s\\w$]*
+                )?
+              )
             \\] |
             (?:
               [a-zA-Z_$][\\w$]*

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -1582,6 +1582,16 @@ describe "Javascript grammar", ->
       expect(tokens[6]).toEqual value: 'parameter.property', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
       expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
+      {tokens} = grammar.tokenizeLine('/** @param {object} [parameter.property] this is the description */')
+      expect(tokens[4]).toEqual value: '{object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '[parameter.property]', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {object} [parameter.property=default value] this is the description */')
+      expect(tokens[4]).toEqual value: '{object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '[parameter.property=default value]', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
       {tokens} = grammar.tokenizeLine('/** @param {*} variable this is the description */')
       expect(tokens[4]).toEqual value: '{*}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
       expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
@@ -1596,6 +1606,7 @@ describe "Javascript grammar", ->
       expect(tokens[4]).toEqual value: '{myNamespace.MyClass}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
       expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
       expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
 
       {tokens} = grammar.tokenizeLine('/** @type {Function|String} callback - Something to call */')
       expect(tokens[4]).toEqual value: '{Function|String}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -1572,9 +1572,24 @@ describe "Javascript grammar", ->
       expect(tokens[6]).toEqual value: '[variable]', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
       expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
+      {tokens} = grammar.tokenizeLine('/** @param {object} [ variable ] this is the description */')
+      expect(tokens[4]).toEqual value: '{object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '[ variable ]', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
       {tokens} = grammar.tokenizeLine('/** @param {object} [variable=default value] this is the description */')
       expect(tokens[4]).toEqual value: '{object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
       expect(tokens[6]).toEqual value: '[variable=default value]', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {object} [variable = default value] this is the description */')
+      expect(tokens[4]).toEqual value: '{object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '[variable = default value]', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {object} [ variable = default value ] this is the description */')
+      expect(tokens[4]).toEqual value: '{object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '[ variable = default value ]', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
       expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {object} parameter.property this is the description */')
@@ -1587,9 +1602,24 @@ describe "Javascript grammar", ->
       expect(tokens[6]).toEqual value: '[parameter.property]', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
       expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
+      {tokens} = grammar.tokenizeLine('/** @param {object} [ parameter.property ] this is the description */')
+      expect(tokens[4]).toEqual value: '{object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '[ parameter.property ]', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
       {tokens} = grammar.tokenizeLine('/** @param {object} [parameter.property=default value] this is the description */')
       expect(tokens[4]).toEqual value: '{object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
       expect(tokens[6]).toEqual value: '[parameter.property=default value]', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {object} [parameter.property = default value] this is the description */')
+      expect(tokens[4]).toEqual value: '{object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '[parameter.property = default value]', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {object} [ parameter.property = default value ] this is the description */')
+      expect(tokens[4]).toEqual value: '{object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '[ parameter.property = default value ]', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
       expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {*} variable this is the description */')
@@ -1606,7 +1636,6 @@ describe "Javascript grammar", ->
       expect(tokens[4]).toEqual value: '{myNamespace.MyClass}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
       expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
       expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
-
 
       {tokens} = grammar.tokenizeLine('/** @type {Function|String} callback - Something to call */')
       expect(tokens[4]).toEqual value: '{Function|String}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']


### PR DESCRIPTION
This PR fixes 2 issues with optional and default values when using the param square bracket syntax and when using valid whitespace.

```js
/**
 * @param {string} [foo] - optional value
 * @param {string} [foo=bar] - default value
 */
```

## Fix 1 - Param props + optionals or defaults

### Before
![screen shot 2016-08-31 at 23 32 40](https://cloud.githubusercontent.com/assets/2854338/18148705/3c428ce2-6fd3-11e6-9b35-590c970147d1.png)

### After
![screen shot 2016-08-31 at 23 31 55](https://cloud.githubusercontent.com/assets/2854338/18148690/1e6615a4-6fd3-11e6-99ae-9ad1db6bf405.png)

## Fix 2 - Optionals or defaults and valid whitespace

### Before
![screen shot 2016-08-31 at 23 34 49](https://cloud.githubusercontent.com/assets/2854338/18148758/97a378b2-6fd3-11e6-8b40-5ffe5df91074.png)

### After
![screen shot 2016-08-31 at 23 35 14](https://cloud.githubusercontent.com/assets/2854338/18148764/9c551064-6fd3-11e6-803c-7bf1a598bb04.png)
