### PR TITLE
Allow tilde char in JSDoc types

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1801,7 +1801,7 @@
                   <[\\w$]+(?:,\\s+[\\w$]+)*>             # {Array<string>} or {Object<string, number>} type application
                 )
                 (?:
-                  [\\.|]                                 # Check for . namespaced types {Foo.bar} or | for multiple types {string|number}
+                  [\\.|~]                                # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
                   [a-zA-Z_$]+
                   (?:
                     [\\w$]* |
@@ -1815,7 +1815,7 @@
                 <[\\w$]+(?:,\\s+[\\w$]+)*>               # {Array<string>} or {Object<string, number>} type application
               )
               (?:
-                [\\.|]                                   # Check for . namespaced types {Foo.bar} or | for multiple types {string|number}
+                [\\.|~]                                  # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
                 [a-zA-Z_$]+
                 (?:
                   [\\w$]* |
@@ -1886,7 +1886,7 @@
                   <[\\w$]+(?:,\\s+[\\w$]+)*>             # {Array<string>} or {Object<string, number>} type application
                 )
                 (?:
-                  [\\.|]                                 # Check for . namespaced types {Foo.bar} or | for multiple types {string|number}
+                  [\\.|~]                                # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
                   [a-zA-Z_$]+
                   (?:
                     [\\w$]* |
@@ -1900,7 +1900,7 @@
                 <[\\w$]+(?:,\\s+[\\w$]+)*>               # {Array<string>} or {Object<string, number>} type application
               )
               (?:
-                [\\.|]                                   # Check for . namespaced types {Foo.bar} or | for multiple types {string|number}
+                [\\.|~]                                  # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
                 [a-zA-Z_$]+
                 (?:
                   [\\w$]* |

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -1701,6 +1701,11 @@ describe "Javascript grammar", ->
       expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
       expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
+      {tokens} = grammar.tokenizeLine('/** @param {Foo~cb} variable this is the description */')
+      expect(tokens[4]).toEqual value: '{Foo~cb}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
       {tokens} = grammar.tokenizeLine('/** @return {object} this is the description */')
       expect(tokens[4]).toEqual value: '{object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
       expect(tokens[6]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']


### PR DESCRIPTION
This PR adds support for the tilde `~` char in JSDoc types that is used to signify class-specific callbacks http://usejsdoc.org/tags-callback.html

### Before
![screen shot 2016-09-01 at 20 10 21](https://cloud.githubusercontent.com/assets/2854338/18180753/22994e54-7080-11e6-9deb-202cd0f8f4b6.png)

### After

![screen shot 2016-09-01 at 20 09 56](https://cloud.githubusercontent.com/assets/2854338/18180758/27499c06-7080-11e6-8cd8-82be24762704.png)
