### PR TITLE
Improve JSDoc square bracket support

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1834,6 +1834,7 @@
               (?:
                 [a-zA-Z_$][\\w$]*
                 (?:
+                  (?:\\[\\])?                            # Foo[].bar properties within an array
                   \\.                                    # Foo.Bar namespaced parameter
                   [a-zA-Z_$][\\w$]*
                 )*
@@ -1849,7 +1850,9 @@
             (?:
               [a-zA-Z_$][\\w$]*
               (?:
-                \\.[a-zA-Z_$][\\w$]*                     # Foo.Bar namespaced parameter
+                (?:\\[\\])?                              # Foo[].bar properties within an array
+                \\.                                      # Foo.Bar namespaced parameter
+                [a-zA-Z_$][\\w$]*
               )*
             )?
           )

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1797,21 +1797,30 @@
               \\(                                        # Opening bracket of multiple types with parenthesis {(string|number)}
                 [a-zA-Z_$]+
                 (?:
-                  [\\w$]* |
+                  (?:
+                    [\\w$]*
+                    (?:\\[\\])?                          # {(string[]|number)} type application, an array of strings or a number
+                  ) |
                   <[\\w$]+(?:,\\s+[\\w$]+)*>             # {Array<string>} or {Object<string, number>} type application
                 )
                 (?:
                   [\\.|]                                 # Check for . namespaced types {Foo.bar} or | for multiple types {string|number}
                   [a-zA-Z_$]+
                   (?:
-                    [\\w$]* |
+                    (?:
+                      [\\w$]*
+                      (?:\\[\\])?                        # {(string|number[])} type application, a string or an array of numbers
+                    ) |
                     <[\\w$]+(?:,\\s+[\\w$]+)*>           # {Array<string>} or {Object<string, number>} type application
                   )
                 )*
               \\) |
               [a-zA-Z_$]+
               (?:
-                [\\w$]* |
+                (?:
+                  [\\w$]*
+                  (?:\\[\\])?                            # {string[]|number} type application, an array of strings or a number
+                ) |
                 <[\\w$]+(?:,\\s+[\\w$]+)*>               # {Array<string>} or {Object<string, number>} type application
               )
               (?:

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -1671,6 +1671,11 @@ describe "Javascript grammar", ->
       expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
       expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
+      {tokens} = grammar.tokenizeLine('/** @param {Foo[].bar} variable this is the description */')
+      expect(tokens[4]).toEqual value: '{Foo[].bar}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
       {tokens} = grammar.tokenizeLine('/** @param {Array<number>} variable this is the description */')
       expect(tokens[4]).toEqual value: '{Array<number>}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
       expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -1637,14 +1637,36 @@ describe "Javascript grammar", ->
       expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
       expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
-      {tokens} = grammar.tokenizeLine('/** @type {Function|String} callback - Something to call */')
-      expect(tokens[4]).toEqual value: '{Function|String}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
-      expect(tokens[6]).toEqual value: 'callback', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      {tokens} = grammar.tokenizeLine('/** @type {function|string} variable this is the description */')
+      expect(tokens[4]).toEqual value: '{function|string}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
-      {tokens} = grammar.tokenizeLine('/** @param {(Number|Function)} types - Bracket notation */')
+      {tokens} = grammar.tokenizeLine('/** @param {string[]|number} variable this is the description */')
+      expect(tokens[4]).toEqual value: '{string[]|number}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {string|number[]} variable this is the description */')
+      expect(tokens[4]).toEqual value: '{string|number[]}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {(number|function)} variable this is the description */')
       expect(tokens[2]).toEqual value: '@param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
-      expect(tokens[4]).toEqual value: '{(Number|Function)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
-      expect(tokens[6]).toEqual value: 'types', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[4]).toEqual value: '{(number|function)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {(string[]|number)} variable this is the description */')
+      expect(tokens[4]).toEqual value: '{(string[]|number)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {(string|number[])} variable this is the description */')
+      expect(tokens[4]).toEqual value: '{(string|number[])}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {?number} variable this is the description */')
       expect(tokens[4]).toEqual value: '{?number}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']


### PR DESCRIPTION
This PR fixes 2 issues with valid syntax that uses square brackets and JSDoc.

## Fix 1 - `[]` used to signify properties within an array

### Before
![screen shot 2016-09-01 at 20 43 11](https://cloud.githubusercontent.com/assets/2854338/18185442/8e3739b8-7095-11e6-9665-108350a30e10.png)

### After
![screen shot 2016-09-01 at 22 43 56](https://cloud.githubusercontent.com/assets/2854338/18185457/9b1c7a58-7095-11e6-902a-909efa2f560f.png)

## Fix 2 - Type application within a union type

### Before
![screen shot 2016-09-01 at 22 45 21](https://cloud.githubusercontent.com/assets/2854338/18185489/c97469ec-7095-11e6-99a6-b50ded279559.png)

### After
![screen shot 2016-09-01 at 22 45 02](https://cloud.githubusercontent.com/assets/2854338/18185493/ceef0e54-7095-11e6-84cf-93751e883b9f.png)

