### PR TITLE
added .ts to grammers/javascript.cson for TypeScript language support

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -13,6 +13,7 @@
   'jspre'
   'pac'
   'pjs'
+  'ts'
   'xsjs'
   'xsjslib'
 ]


### PR DESCRIPTION
Not sure if this will work, but just wanted to add potential TypeScript support for the syntax highlighter.