### PR TITLE
Return control to language-html when </script> is detected when embedded

### DIFF
--- a/grammars/embedded javascript.cson
+++ b/grammars/embedded javascript.cson
@@ -1,30 +1,10 @@
 'scopeName': 'source.js.embedded.html'
 'name': 'Embedded JavaScript'
-'injectionSelector': 'L:source.js.embedded.html'
+'injectionSelector': 'L:source.js.embedded.html, L:source.js.embedded.xml'
 'patterns': [
   {
-    'begin': '(^[ \\t]+)?(?=//)'
-    'beginCaptures':
-      '1':
-        'name': 'punctuation.whitespace.comment.leading.js'
-    'end': '(?!\\G)'
-    'patterns': [
-      {
-        'begin': '//'
-        'beginCaptures':
-          '0':
-            'name': 'punctuation.definition.comment.js'
-        'end': '(?=</script>)|\\n'
-        'name': 'comment.line.double-slash.js'
-      }
-    ]
-  }
-  {
-    'begin': '<!--|-->'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.comment.html.js'
-    'end': '(?=</script>)|$'
-    'name': 'comment.line.deprecated.html.js'
+    # Break out as soon as a </script> tag is encountered,
+    # even if it's in a string or comment
+    'match': '(?=</script>)'
   }
 ]

--- a/grammars/embedded javascript.cson
+++ b/grammars/embedded javascript.cson
@@ -1,0 +1,30 @@
+'scopeName': 'source.js.embedded.html'
+'name': 'Embedded JavaScript'
+'injectionSelector': 'L:source.js.embedded.html'
+'patterns': [
+  {
+    'begin': '(^[ \\t]+)?(?=//)'
+    'beginCaptures':
+      '1':
+        'name': 'punctuation.whitespace.comment.leading.js'
+    'end': '(?!\\G)'
+    'patterns': [
+      {
+        'begin': '//'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.comment.js'
+        'end': '(?=</script>)|\\n'
+        'name': 'comment.line.double-slash.js'
+      }
+    ]
+  }
+  {
+    'begin': '<!--|-->'
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.comment.html.js'
+    'end': '(?=</script>)|$'
+    'name': 'comment.line.deprecated.html.js'
+  }
+]

--- a/grammars/embedded javascript.cson
+++ b/grammars/embedded javascript.cson
@@ -5,6 +5,6 @@
   {
     # Break out as soon as a </script> tag is encountered,
     # even if it's in a string or comment
-    'match': '(?=</script>)'
+    'match': '(?=</(?i:script)\\s*>)'
   }
 ]

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1,4 +1,5 @@
 'scopeName': 'source.js'
+'name': 'JavaScript'
 'fileTypes': [
   'js'
   '_js'
@@ -35,7 +36,6 @@
     (?=\\s|:|$)
   )
 '''
-'name': 'JavaScript'
 'patterns': [
   {
     # ES6 import
@@ -826,15 +826,6 @@
   }
   {
     'include': '#comments'
-  }
-  {
-    'match': '(<!--|-->)'
-    'captures':
-      '0':
-        'name': 'punctuation.definition.comment.html.js'
-      '2':
-        'name': 'punctuation.definition.comment.html.js'
-    'name': 'comment.block.html.js'
   }
   {
     'match': '(?<!\\.)\\b(class|enum|function|interface)(?!\\s*:)\\b'
@@ -1999,6 +1990,14 @@
             'name': 'comment.line.double-slash.js'
           }
         ]
+      }
+      {
+        'begin': '<!--|-->'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.comment.html.js'
+        'end': '$'
+        'name': 'comment.line.deprecated.html.js'
       }
     ]
   'switch_statement':

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -1851,6 +1851,19 @@ describe "Javascript grammar", ->
       expect(tokens[7]).toEqual value: ', p2 ', scopes: ['source.js', 'meta.function.js', 'meta.parameters.js', 'comment.block.js']
       expect(tokens[8]).toEqual value: '*/', scopes: ['source.js', 'meta.function.js', 'meta.parameters.js', 'comment.block.js', 'punctuation.definition.comment.js']
 
+    it "tokenizes deprecated HTML-style comments correctly", ->
+      {tokens} = grammar.tokenizeLine('<!-- test')
+      expect(tokens[0]).toEqual value: '<!--', scopes: ['source.js', 'comment.line.deprecated.html.js', 'punctuation.definition.comment.html.js']
+      expect(tokens[1]).toEqual value: ' test', scopes: ['source.js', 'comment.line.deprecated.html.js']
+
+      {tokens} = grammar.tokenizeLine('--> test')
+      expect(tokens[0]).toEqual value: '-->', scopes: ['source.js', 'comment.line.deprecated.html.js', 'punctuation.definition.comment.html.js']
+      expect(tokens[1]).toEqual value: ' test', scopes: ['source.js', 'comment.line.deprecated.html.js']
+
+      {tokens} = grammar.tokenizeLine('<!-- test --> console.log()')
+      expect(tokens[0]).toEqual value: '<!--', scopes: ['source.js', 'comment.line.deprecated.html.js', 'punctuation.definition.comment.html.js']
+      expect(tokens[1]).toEqual value: ' test --> console.log()', scopes: ['source.js', 'comment.line.deprecated.html.js']
+
   describe "console", ->
     it "tokenizes the console keyword", ->
       {tokens} = grammar.tokenizeLine('console;')


### PR DESCRIPTION
When embedded, a </script> tag will break out of the script block even if it would otherwise be in a comment or string.  There's no way to catch when we're embedded with javascript.cson, but we can do it using an injectionSelector.

Supersedes and closes #371.
Blocked on atom/first-mate#78.
Unblocks atom/language-html#90.