### PR TITLE
Improve JSDoc grammar

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1884,6 +1884,7 @@
             )?
           )
           \\s+
+          (?:-\\s+)?                                     # optional hyphen before the description
           ((?:(?!\\*\\/).)*)                             # The type description
         '''
         'captures':
@@ -1943,6 +1944,7 @@
             =?                                           # {string=} optional parameter
           )})
           \\s+
+          (?:-\\s+)?                                     # optional hyphen before the description
           ((?:(?!\\*\\/).)*)                             # The type description
         '''
         'captures':

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1799,7 +1799,7 @@
       }
       {
         'match': '''(?x)
-          (?:(?<=@param)|(?<=@type))
+          (?:(?<=@param)|(?<=@arg)|(?<=@argument)|(?<=@type))
           \\s+
           ({(?:
             \\* |                                        # {*} any type

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -1566,6 +1566,20 @@ describe "Javascript grammar", ->
       expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
       expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
+      {tokens} = grammar.tokenizeLine('/** @arg {object} variable this is the description */')
+      expect(tokens[4]).toEqual value: '{object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @argument {object} variable this is the description */')
+      expect(tokens[4]).toEqual value: '{object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {object} variable - this is the description */')
+      expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
       {tokens} = grammar.tokenizeLine('/** @param {object} $variable this is the description */')
       expect(tokens[4]).toEqual value: '{object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
       expect(tokens[6]).toEqual value: '$variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']


### PR DESCRIPTION
- Add `@param` synonyms `@arg` and `@argument`
- Remove the hyphen before the description from the capture

See: http://usejsdoc.org/tags-param.html