### PR TITLE
Add basic JSDoc function type support

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1858,7 +1858,7 @@
                   | tutorial
                 )
               )
-              
+
               \\s+
 
               ([^\\s|}]+)        # Namepath or URL
@@ -1898,16 +1898,21 @@
 
               (?:
                 (?:
-                  function\\(                           # {function(string, number)} function type
+                  function                              # {function(string, number)} function type
+                  \\s*
+                  \\(
+                  \\s*
+                  (?:
+                    [a-zA-Z_$][\\w$]*
                     (?:
-                      \\s*
-                      [a-zA-Z_$]
-                      (?:\\s*,\\s*[\\w$])*
-                      \\s*
+                      \\s*,\\s*
+                      [a-zA-Z_$][\\w$]*
                     )*
+                  )?
+                  \\s*
                   \\)
-                )? |
-
+                )?
+                |
                 (?:
                   \\(                                   # Opening bracket of multiple types with parenthesis {(string|number)}
                     [a-zA-Z_$]+
@@ -2011,16 +2016,21 @@
 
               (?:
                 (?:
-                  function\\(                           # {function(string, number)} function type
+                  function                              # {function(string, number)} function type
+                  \\s*
+                  \\(
+                  \\s*
+                  (?:
+                    [a-zA-Z_$][\\w$]*
                     (?:
-                      \\s*
-                      [a-zA-Z_$]
-                      (?:\\s*,\\s*[\\w$])*
-                      \\s*
+                      \\s*,\\s*
+                      [a-zA-Z_$][\\w$]*
                     )*
+                  )?
+                  \\s*
                   \\)
-                )? |
-
+                )?
+                |
                 (?:
                   \\(                                   # Opening bracket of multiple types with parenthesis {(string|number)}
                     [a-zA-Z_$]+

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1886,72 +1886,87 @@
           (?:(?<=@param)|(?<=@arg)|(?<=@argument)|(?<=@type))
           \\s+
           ({(?:
-            \\* |                                        # {*} any type
-            \\? |                                        # {?} unknown type
-
-            (?:                                          # Check for a prefix
-              \\? |                                      # {?string} nullable type
-              !   |                                      # {!string} non-nullable type
-              \\.{3}                                     # {...string} variable number of parameters
-            )?
+            \\* |                                       # {*} any type
+            \\? |                                       # {?} unknown type
 
             (?:
-              \\(                                        # Opening bracket of multiple types with parenthesis {(string|number)}
-                [a-zA-Z_$]+
+              (?:                                       # Check for a prefix
+                \\? |                                   # {?string} nullable type
+                !   |                                   # {!string} non-nullable type
+                \\.{3}                                  # {...string} variable number of parameters
+              )?
+
+              (?:
                 (?:
-                  (?:
-                    [\\w$]*
-                    (?:\\[\\])?                          # {(string[]|number)} type application, an array of strings or a number
-                  ) |
-                  \\.?<[\\w$]+(?:,\\s+[\\w$]+)*>         # {Array<string>} or {Object<string, number>} type application (optional .)
-                )
+                  function\\(                           # {function(string, number)} function type
+                    (?:
+                      \\s*
+                      [a-zA-Z_$]
+                      (?:\\s*,\\s*[\\w$])*
+                      \\s*
+                    )*
+                  \\)
+                )? |
+
                 (?:
-                  [\\.|~]                                # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
+                  \\(                                   # Opening bracket of multiple types with parenthesis {(string|number)}
+                    [a-zA-Z_$]+
+                    (?:
+                      (?:
+                        [\\w$]*
+                        (?:\\[\\])?                     # {(string[]|number)} type application, an array of strings or a number
+                      ) |
+                      \\.?<[\\w$]+(?:,\\s+[\\w$]+)*>    # {Array<string>} or {Object<string, number>} type application (optional .)
+                    )
+                    (?:
+                      [\\.|~]                           # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
+                      [a-zA-Z_$]+
+                      (?:
+                        (?:
+                          [\\w$]*
+                          (?:\\[\\])?                   # {(string|number[])} type application, a string or an array of numbers
+                        ) |
+                        \\.?<[\\w$]+(?:,\\s+[\\w$]+)*>  # {Array<string>} or {Object<string, number>} type application (optional .)
+                      )
+                    )*
+                  \\) |
                   [a-zA-Z_$]+
                   (?:
                     (?:
                       [\\w$]*
-                      (?:\\[\\])?                        # {(string|number[])} type application, a string or an array of numbers
+                      (?:\\[\\])?                       # {(string|number[])} type application, a string or an array of numbers
                     ) |
-                    \\.?<[\\w$]+(?:,\\s+[\\w$]+)*>       # {Array<string>} or {Object<string, number>} type application (optional .)
+                    \\.?<[\\w$]+(?:,\\s+[\\w$]+)*>      # {Array<string>} or {Object<string, number>} type application (optional .)
                   )
-                )*
-              \\) |
-              [a-zA-Z_$]+
-              (?:
-                (?:
-                  [\\w$]*
-                  (?:\\[\\])?                            # {string[]|number} type application, an array of strings or a number
-                ) |
-                \\.?<[\\w$]+(?:,\\s+[\\w$]+)*>           # {Array<string>} or {Object<string, number>} type application (optional .)
-              )
-              (?:
-                [\\.|~]                                  # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
-                [a-zA-Z_$]+
-                (?:
-                  [\\w$]* |
-                  \\.?<[\\w$]+(?:,\\s+[\\w$]+)*>         # {Array<string>} or {Object<string, number>} type application (optional .)
+                  (?:
+                    [\\.|~]                             # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
+                    [a-zA-Z_$]+
+                    (?:
+                      [\\w$]* |
+                      \\.?<[\\w$]+(?:,\\s+[\\w$]+)*>    # {Array<string>} or {Object<string, number>} type application (optional .)
+                    )
+                  )*
                 )
-              )*
+              )
+                                                        # Check for suffix
+              (?:\\[\\])?                               # {string[]} type application, an array of strings
+              =?                                        # {string=} optional parameter
             )
-                                                         # Check for suffix
-            (?:\\[\\])?                                  # {string[]} type application, an array of strings
-            =?                                           # {string=} optional parameter
           )})
           \\s+
           (
-            \\[                                          # [foo] optional parameter
+            \\[                                         # [foo] optional parameter
               \\s*
               (?:
                 [a-zA-Z_$][\\w$]*
                 (?:
-                  (?:\\[\\])?                            # Foo[].bar properties within an array
-                  \\.                                    # Foo.Bar namespaced parameter
+                  (?:\\[\\])?                           # Foo[].bar properties within an array
+                  \\.                                   # Foo.Bar namespaced parameter
                   [a-zA-Z_$][\\w$]*
                 )*
                 (?:
                   \\s*
-                  =                                      # [foo=bar] Default parameter value
+                  =                                     # [foo=bar] Default parameter value
                   \\s*
                   [\\w$\\s]*
                 )?
@@ -1961,8 +1976,8 @@
             (?:
               [a-zA-Z_$][\\w$]*
               (?:
-                (?:\\[\\])?                              # Foo[].bar properties within an array
-                \\.                                      # Foo.Bar namespaced parameter
+                (?:\\[\\])?                             # Foo[].bar properties within an array
+                \\.                                     # Foo.Bar namespaced parameter
                 [a-zA-Z_$][\\w$]*
               )*
             )?
@@ -1984,52 +1999,67 @@
       {
         'match': '''(?x)
           ({(?:
-            \\* |                                        # {*} any type
-            \\? |                                        # {?} unknown type
-
-            (?:                                          # Check for a prefix
-              \\? |                                      # {?string} nullable type
-              !   |                                      # {!string} non-nullable type
-              \\.{3}                                     # {...string} variable number of parameters
-            )?
+            \\* |                                       # {*} any type
+            \\? |                                       # {?} unknown type
 
             (?:
-              \\(                                        # Opening bracket of multiple types with parenthesis {(string|number)}
-                [a-zA-Z_$]+
+              (?:                                       # Check for a prefix
+                \\? |                                   # {?string} nullable type
+                !   |                                   # {!string} non-nullable type
+                \\.{3}                                  # {...string} variable number of parameters
+              )?
+
+              (?:
                 (?:
-                  [\\w$]* |
-                  \\.?<[\\w$]+(?:,\\s+[\\w$]+)*>         # {Array<string>} or {Object<string, number>} type application (optional .)
-                )
+                  function\\(                           # {function(string, number)} function type
+                    (?:
+                      \\s*
+                      [a-zA-Z_$]
+                      (?:\\s*,\\s*[\\w$])*
+                      \\s*
+                    )*
+                  \\)
+                )? |
+
                 (?:
-                  [\\.|~]                                # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
+                  \\(                                   # Opening bracket of multiple types with parenthesis {(string|number)}
+                    [a-zA-Z_$]+
+                    (?:
+                      [\\w$]* |
+                      \\.?<[\\w$]+(?:,\\s+[\\w$]+)*>    # {Array<string>} or {Object<string, number>} type application (optional .)
+                    )
+                    (?:
+                      [\\.|~]                           # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
+                      [a-zA-Z_$]+
+                      (?:
+                        [\\w$]* |
+                        \\.?<[\\w$]+(?:,\\s+[\\w$]+)*>  # {Array<string>} or {Object<string, number>} type application (optional .)
+                      )
+                    )*
+                  \\) |
                   [a-zA-Z_$]+
                   (?:
                     [\\w$]* |
-                    \\.?<[\\w$]+(?:,\\s+[\\w$]+)*>       # {Array<string>} or {Object<string, number>} type application (optional .)
+                    \\.?<[\\w$]+(?:,\\s+[\\w$]+)*>      # {Array<string>} or {Object<string, number>} type application (optional .)
                   )
-                )*
-              \\) |
-              [a-zA-Z_$]+
-              (?:
-                [\\w$]* |
-                \\.?<[\\w$]+(?:,\\s+[\\w$]+)*>           # {Array<string>} or {Object<string, number>} type application (optional .)
-              )
-              (?:
-                [\\.|~]                                  # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
-                [a-zA-Z_$]+
-                (?:
-                  [\\w$]* |
-                  \\.?<[\\w$]+(?:,\\s+[\\w$]+)*>         # {Array<string>} or {Object<string, number>} type application (optional .)
+                  (?:
+                    [\\.|~]                             # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
+                    [a-zA-Z_$]+
+                    (?:
+                      [\\w$]* |
+                      \\.?<[\\w$]+(?:,\\s+[\\w$]+)*>    # {Array<string>} or {Object<string, number>} type application (optional .)
+                    )
+                  )*
                 )
-              )*
+              )
+                                                        # Check for suffix
+              (?:\\[\\])?                               # {string[]} type application, an array of strings
+              =?                                        # {string=} optional parameter
             )
-                                                         # Check for suffix
-            (?:\\[\\])?                                  # {string[]} type application, an array of strings
-            =?                                           # {string=} optional parameter
           )})
           \\s+
-          (?:-\\s+)?                                     # optional hyphen before the description
-          ((?:(?!\\*\\/).)*)                             # The type description
+          (?:-\\s+)?                                    # optional hyphen before the description
+          ((?:(?!\\*\\/).)*)                            # The type description
         '''
         'captures':
           '0':

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -1979,6 +1979,16 @@ describe "JavaScript grammar", ->
       expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
       expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
+      {tokens} = grammar.tokenizeLine('/** @param {function ()} variable this is the description */')
+      expect(tokens[4]).toEqual value: '{function ()}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {function ( )} variable this is the description */')
+      expect(tokens[4]).toEqual value: '{function ( )}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
       {tokens} = grammar.tokenizeLine('/** @param {function(string)} variable this is the description */')
       expect(tokens[4]).toEqual value: '{function(string)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
       expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
@@ -2011,6 +2021,14 @@ describe "JavaScript grammar", ->
 
       {tokens} = grammar.tokenizeLine('/** @return {function()} this is the description */')
       expect(tokens[4]).toEqual value: '{function()}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @return {function ()} this is the description */')
+      expect(tokens[4]).toEqual value: '{function ()}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @return {function ( )} this is the description */')
+      expect(tokens[4]).toEqual value: '{function ( )}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
       expect(tokens[6]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function(string)} this is the description */')

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -1974,6 +1974,21 @@ describe "JavaScript grammar", ->
       expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
       expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
+      {tokens} = grammar.tokenizeLine('/** @param {function()} variable this is the description */')
+      expect(tokens[4]).toEqual value: '{function()}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {function(string)} variable this is the description */')
+      expect(tokens[4]).toEqual value: '{function(string)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {function(string, number)} variable this is the description */')
+      expect(tokens[4]).toEqual value: '{function(string, number)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
       {tokens} = grammar.tokenizeLine('/** @return {object} this is the description */')
       expect(tokens[4]).toEqual value: '{object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
       expect(tokens[6]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
@@ -1993,6 +2008,18 @@ describe "JavaScript grammar", ->
 
       {tokens} = grammar.tokenizeLine('/** @returns {(Something)} */')
       expect(tokens[4]).toEqual value: '{(Something)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @return {function()} this is the description */')
+      expect(tokens[4]).toEqual value: '{function()}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @return {function(string)} this is the description */')
+      expect(tokens[4]).toEqual value: '{function(string)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @return {function(string, number)} this is the description */')
+      expect(tokens[4]).toEqual value: '{function(string, number)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
     it "tokenizes // comments", ->
       {tokens} = grammar.tokenizeLine('// comment')


### PR DESCRIPTION
This is the first of a couple of PRs that add JSDoc support for the [function type](https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler#function-type).

Since it effects the indentation of quite a few lines it might be easier to review with [whitespace changes off](https://github.com/atom/language-javascript/compare/master...bgriffith:feature/basic-function-jsdoc?expand=1&w=1).

![jsdoc-function](https://cloud.githubusercontent.com/assets/2854338/19416945/1565c430-9397-11e6-98b7-a16d06ddad12.png)
