### PR TITLE
Missing single line comment <!--

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -2086,7 +2086,7 @@
         'end': '(?!\\G)'
         'patterns': [
           {
-            'begin': '//'
+            'begin': '(//|<!--)'
             'beginCaptures':
               '0':
                 'name': 'punctuation.definition.comment.js'


### PR DESCRIPTION
There are two ways of using single line comments in Javascript:

1. The usual way with two consecutive slashes `//`
2. An obscure but also valid `<!--` as the start of the html block comments

The following two lines are completely valid in Javascript:

```javascript
1 + 1 == 2 // usual
1 + 1 == 0 <!-- obscure
```