### PR TITLE
Fix #452: Wrong scopes for methods named "import"

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -39,7 +39,7 @@
 'patterns': [
   {
     # ES6 import
-    'begin': '(?<!\\.)\\b(import)(?!\\s*:)\\b'
+    'begin': '(?<!\\.)\\b(import)(?!\\s*[:(])\\b'
     'beginCaptures':
       '1':
         'name': 'keyword.control.js'
@@ -161,7 +161,7 @@
   }
   {
     # ES6 export, re-export: export {member as alias, [...]} [from ...]
-    'begin': '(?<!\\.)\\b(export)(?!\\s*:)\\b'
+    'begin': '(?<!\\.)\\b(export)(?!\\s*[:(])\\b'
     'beginCaptures':
       '1':
         'name': 'keyword.control.js'
@@ -464,8 +464,8 @@
     'begin': '''(?x)
       (?=
         (?!
-          (break|case|catch|continue|do|else|finally|for|function|if|export|
-          import|package|return|switch|throw|try|while|with)
+          (break|case|catch|continue|do|else|finally|for|function|if|
+          package|return|switch|throw|try|while|with)
           [\\s\\(]
         )
         (

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -1249,6 +1249,14 @@ describe "Javascript grammar", ->
       {tokens} = grammar.tokenizeLine('"func" : a => a')
       expect(tokens[8]).toEqual value: '=>', scopes: ['source.js', 'meta.function.arrow.json.js', 'storage.type.function.arrow.js']
 
+      {tokens} = grammar.tokenizeLine('import (x) { return "Yeah"; }')
+      expect(tokens[0]).toEqual value: 'import', scopes: ['source.js', 'meta.function.method.definition.js', 'entity.name.function.js']
+      expect(tokens[11]).toEqual value: 'Yeah', scopes: ['source.js', 'string.quoted.double.js']
+
+      {tokens} = grammar.tokenizeLine('export (x) { return "Nah"; }')
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'meta.function.method.definition.js', 'entity.name.function.js']
+      expect(tokens[11]).toEqual value: 'Nah', scopes: ['source.js', 'string.quoted.double.js']
+
     it "tokenizes generator functions", ->
       {tokens} = grammar.tokenizeLine('function* foo(){}')
       expect(tokens[0]).toEqual value: 'function', scopes: ['source.js', 'meta.function.js', 'storage.type.function.js']

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -1069,6 +1069,14 @@ describe "Javascript grammar", ->
       expect(tokens[5]).toEqual value: ')', scopes: ['source.js', 'meta.function-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
       expect(tokens[6]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
 
+      {tokens} = grammar.tokenizeLine('import (x) { return "Yeah"; }')
+      expect(tokens[0]).toEqual value: 'import', scopes: ['source.js', 'meta.function.method.definition.js', 'entity.name.function.js']
+      expect(tokens[11]).toEqual value: 'Yeah', scopes: ['source.js', 'string.quoted.double.js']
+
+      {tokens} = grammar.tokenizeLine('export (x) { return "Nah"; }')
+      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'meta.function.method.definition.js', 'entity.name.function.js']
+      expect(tokens[11]).toEqual value: 'Nah', scopes: ['source.js', 'string.quoted.double.js']
+
     it "tokenises ES6 methods with computed names", ->
       {tokens} = grammar.tokenizeLine('[ foo ] () { }')
       expect(tokens[0]).toEqual value: '[', scopes: ['source.js', 'meta.function.method.definition.js', 'meta.computed-key.js', 'punctuation.definition.computed-key.begin.bracket.square.js']
@@ -1248,14 +1256,6 @@ describe "Javascript grammar", ->
 
       {tokens} = grammar.tokenizeLine('"func" : a => a')
       expect(tokens[8]).toEqual value: '=>', scopes: ['source.js', 'meta.function.arrow.json.js', 'storage.type.function.arrow.js']
-
-      {tokens} = grammar.tokenizeLine('import (x) { return "Yeah"; }')
-      expect(tokens[0]).toEqual value: 'import', scopes: ['source.js', 'meta.function.method.definition.js', 'entity.name.function.js']
-      expect(tokens[11]).toEqual value: 'Yeah', scopes: ['source.js', 'string.quoted.double.js']
-
-      {tokens} = grammar.tokenizeLine('export (x) { return "Nah"; }')
-      expect(tokens[0]).toEqual value: 'export', scopes: ['source.js', 'meta.function.method.definition.js', 'entity.name.function.js']
-      expect(tokens[11]).toEqual value: 'Nah', scopes: ['source.js', 'string.quoted.double.js']
 
     it "tokenizes generator functions", ->
       {tokens} = grammar.tokenizeLine('function* foo(){}')


### PR DESCRIPTION
Fixes #452:

```js
import(x) { "ABCDEFGHIJKLMNOPQRSTUVWXYZ"; }
Import(x) { "ABCDEFGHIJKLMNOPQRSTUVWXYZ"; }
```