### PR TITLE
Add JSDoc support for function return type

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1911,8 +1911,8 @@
                   )?
                   \\s*
                   \\)
-                )?
-                |
+                  (?:\\s*:\\s*[a-zA-Z_$]+\\s*)?         # {function(): string} function return type
+                )? |
                 (?:
                   \\(                                   # Opening bracket of multiple types with parenthesis {(string|number)}
                     [a-zA-Z_$]+
@@ -2029,8 +2029,8 @@
                   )?
                   \\s*
                   \\)
-                )?
-                |
+                  (?:\\s*:\\s*[a-zA-Z_$]+\\s*)?         # {function(): string} function return type
+                )? |
                 (?:
                   \\(                                   # Opening bracket of multiple types with parenthesis {(string|number)}
                     [a-zA-Z_$]+

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1911,8 +1911,12 @@
                   )?
                   \\s*
                   \\)
-                  (?:\\s*:\\s*[a-zA-Z_$]+\\s*)?         # {function(): string} function return type
-                )? |
+                  (?:                                   # {function(): string} function return type
+                    \\s*:\\s*
+                    [a-zA-Z_$][\\w$]*
+                  )?
+                )?
+                |
                 (?:
                   \\(                                   # Opening bracket of multiple types with parenthesis {(string|number)}
                     [a-zA-Z_$]+
@@ -2029,8 +2033,12 @@
                   )?
                   \\s*
                   \\)
-                  (?:\\s*:\\s*[a-zA-Z_$]+\\s*)?         # {function(): string} function return type
-                )? |
+                  (?:                                   # {function(): string} function return type
+                    \\s*:\\s*
+                    [a-zA-Z_$][\\w$]*
+                  )?
+                )?
+                |
                 (?:
                   \\(                                   # Opening bracket of multiple types with parenthesis {(string|number)}
                     [a-zA-Z_$]+

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -2009,6 +2009,10 @@ describe "JavaScript grammar", ->
       expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
       expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
+      {tokens} = grammar.tokenizeLine('/** @param {function(string) : number} variable this is the description */')
+      expect(tokens[4]).toEqual value: '{function(string) : number}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {object} this is the description */')
       expect(tokens[4]).toEqual value: '{object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
@@ -2056,6 +2060,10 @@ describe "JavaScript grammar", ->
 
       {tokens} = grammar.tokenizeLine('/** @return {function(string): number} this is the description */')
       expect(tokens[4]).toEqual value: '{function(string): number}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @return {function(string) : number} this is the description */')
+      expect(tokens[4]).toEqual value: '{function(string) : number}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
       expect(tokens[6]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
     it "tokenizes // comments", ->

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -1999,6 +1999,17 @@ describe "JavaScript grammar", ->
       expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
       expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
+      {tokens} = grammar.tokenizeLine('/** @param {function():number} variable this is the description */')
+      expect(tokens[4]).toEqual value: '{function():number}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {function(string): number} variable this is the description */')
+      expect(tokens[4]).toEqual value: '{function(string): number}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+
       {tokens} = grammar.tokenizeLine('/** @return {object} this is the description */')
       expect(tokens[4]).toEqual value: '{object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
       expect(tokens[6]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
@@ -2037,6 +2048,14 @@ describe "JavaScript grammar", ->
 
       {tokens} = grammar.tokenizeLine('/** @return {function(string, number)} this is the description */')
       expect(tokens[4]).toEqual value: '{function(string, number)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @return {function():number} this is the description */')
+      expect(tokens[4]).toEqual value: '{function():number}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @return {function(string): number} this is the description */')
+      expect(tokens[4]).toEqual value: '{function(string): number}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
       expect(tokens[6]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
     it "tokenizes // comments", ->


### PR DESCRIPTION
This PR adds support for [function return type](https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler#function-return-type) with JSDoc.

![screen shot 2016-11-01 at 15 53 35](https://cloud.githubusercontent.com/assets/2854338/19896213/6b6cb760-a04b-11e6-9224-503ce3f57208.png)
