### PR TITLE
Update contributing link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-See the [Atom contributing guide](https://atom.io/docs/latest/contributing)
+See the [Atom contributing guide](https://github.com/atom/atom/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
Currently the contributing link goes to a page with nothing about contributing! So this PR updates the link found in the contributing docs to Atom's.