### PR TITLE
Add support for JSDoc function type param prefixes/suffixes

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1934,17 +1934,45 @@
                 (?:
                   function                              # {function(string, number)} function type
                   \\s*
-                  \\(
-                  \\s*
                   (?:
-                    [a-zA-Z_$][\\w$]*
                     (?:
-                      \\s*,\\s*
-                      [a-zA-Z_$][\\w$]*
-                    )*
-                  )?
-                  \\s*
-                  \\)
+                      \\(
+                      \\s*
+                      \\.{3}[a-zA-Z_$][\\w$]+           # {function(...string)} variable number of parameters
+                      \\s*
+                      \\)
+                    )
+                    |
+                    (?:
+                      \\(
+                      \\s*
+                      (?:
+                        (?:
+                          \\? |                         # {function(?string)} nullable type
+                          !   |                         # {function(!string)} non-nullable type
+                        )?
+                        [a-zA-Z_$][\\w$]+
+                        (?:
+                          \\s*,\\s*
+                          (?:
+                            (?:
+                              (?:
+                                \\? |                   # {function(string, ?string)} nullable type
+                                !   |                   # {function(string, !string)} non-nullable type
+                              )?
+                              [a-zA-Z_$][\\w$]+
+                            )
+                            |
+                            (?:
+                              \\.{3}[a-zA-Z_$][\\w$]+   # {function(string, ...string)} variable number of parameters
+                            )
+                          )
+                        )*
+                      )*
+                      \\s*
+                      \\)
+                    )
+                  )
                   (?:                                   # {function(): string} function return type
                     \\s*:\\s*
                     [a-zA-Z_$][\\w$]*
@@ -2056,17 +2084,45 @@
                 (?:
                   function                              # {function(string, number)} function type
                   \\s*
-                  \\(
-                  \\s*
                   (?:
-                    [a-zA-Z_$][\\w$]*
                     (?:
-                      \\s*,\\s*
-                      [a-zA-Z_$][\\w$]*
-                    )*
-                  )?
-                  \\s*
-                  \\)
+                      \\(
+                      \\s*
+                      \\.{3}[a-zA-Z_$][\\w$]+           # {function(...string)} variable number of parameters
+                      \\s*
+                      \\)
+                    )
+                    |
+                    (?:
+                      \\(
+                      \\s*
+                      (?:
+                        (?:
+                          \\? |                         # {function(?string)} nullable type
+                          !   |                         # {function(!string)} non-nullable type
+                        )?
+                        [a-zA-Z_$][\\w$]+
+                        (?:
+                          \\s*,\\s*
+                          (?:
+                            (?:
+                              (?:
+                                \\? |                   # {function(string, ?string)} nullable type
+                                !   |                   # {function(string, !string)} non-nullable type
+                              )?
+                              [a-zA-Z_$][\\w$]+
+                            )
+                            |
+                            (?:
+                              \\.{3}[a-zA-Z_$][\\w$]+   # {function(string, ...string)} variable number of parameters
+                            )
+                          )
+                        )*
+                      )*
+                      \\s*
+                      \\)
+                    )
+                  )
                   (?:                                   # {function(): string} function return type
                     \\s*:\\s*
                     [a-zA-Z_$][\\w$]*

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1952,6 +1952,7 @@
                           !   |                         # {function(!string)} non-nullable type
                         )?
                         [a-zA-Z_$][\\w$]+
+                        (?:\\[\\])?                     # {function(string[])} type application, an array of strings
                         (?:
                           \\s*,\\s*
                           (?:
@@ -1961,6 +1962,7 @@
                                 !   |                   # {function(string, !string)} non-nullable type
                               )?
                               [a-zA-Z_$][\\w$]+
+                              (?:\\[\\])?               # {function(string[])} type application, an array of strings
                             )
                             |
                             (?:
@@ -1968,6 +1970,7 @@
                             )
                           )
                         )*
+                        =?                              # {function(string=)} optional parameter
                       )*
                       \\s*
                       \\)
@@ -2102,6 +2105,7 @@
                           !   |                         # {function(!string)} non-nullable type
                         )?
                         [a-zA-Z_$][\\w$]+
+                        (?:\\[\\])?                     # {function(string[])} type application, an array of strings
                         (?:
                           \\s*,\\s*
                           (?:
@@ -2111,6 +2115,7 @@
                                 !   |                   # {function(string, !string)} non-nullable type
                               )?
                               [a-zA-Z_$][\\w$]+
+                              (?:\\[\\])?               # {function(string[])} type application, an array of strings
                             )
                             |
                             (?:
@@ -2118,6 +2123,7 @@
                             )
                           )
                         )*
+                        =?                              # {function(string=)} optional parameter
                       )*
                       \\s*
                       \\)

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1936,46 +1936,53 @@
                   \\s*
                   (?:
                     (?:
-                      \\(
-                      \\s*
+                      \\(\\s*
                       \\.{3}[a-zA-Z_$][\\w$]+           # {function(...string)} variable number of parameters
-                      \\s*
-                      \\)
+                      \\s*\\)
                     )
                     |
                     (?:
-                      \\(
-                      \\s*
+                      \\(\\s*
                       (?:
+                        (?:\\?|!)?                      # {function(?string)} or function(!string)} nullable/non-nullable type
+                        [a-zA-Z_$][\\w$]+
+                        (?:\\[\\])?                     # {function(string[])} type application, an array of strings
                         (?:
                           (?:
-                            \\? |                       # {function(?string)} nullable type
-                            !                           # {function(!string)} non-nullable type
-                          )?
-                          [a-zA-Z_$][\\w$]+
-                          (?:\\[\\])?                   # {function(string[])} type application, an array of strings
-                          (?:
-                            \\s*,\\s*
                             (?:
-                              (?:
-                                (?:
-                                  \\? |                 # {function(string, ?string)} nullable type
-                                  !                     # {function(string, !string)} non-nullable type
-                                )?
-                                [a-zA-Z_$][\\w$]+
-                                (?:\\[\\])?             # {function(string[])} type application, an array of strings
-                              )
-                            )
-                          )*
-                          =?                            # {function(string=)} optional parameter
-                        )+
-                        (?:
-                          \\s*,\\s*
-                          \\.{3}[a-zA-Z_$][\\w$]+       # {function(string, ...string)} variable number of parameters
-                        )?
+                              \\s*,\\s*
+                              (?:\\?|!)?                # {function(?string)} or function(!string)} nullable/non-nullable type
+                              [a-zA-Z_$][\\w$]+
+                              (?:\\[\\])?               # {function(string[])} type application, an array of strings
+                            )*
+                            (?:
+                              \\s*,\\s*
+                              \\.{3}[a-zA-Z_$][\\w$]+   # {function(string, ...string)} variable number of parameters
+                            )?
+                          )
+                          |
+                          (?:
+                            =?                          # {function(string=)} optional parameter
+                            (?:
+                              (?<!=)                    # {function(string, string, number)} loop non-optional params
+                              \\s*,\\s*
+                              (?:\\?|!)?                # {function(?string)} or function(!string)} nullable/non-nullable type
+                              [a-zA-Z_$][\\w$]+
+                              (?:\\[\\])?               # {function(string[])} type application, an array of strings
+                              =?
+                            )*
+                            (?:
+                              (?<==)                    # {function(string, string=, number=)} loop optional params
+                              \\s*,\\s*
+                              (?:\\?|!)?                # {function(?string)} or function(!string)} nullable/non-nullable type
+                              [a-zA-Z_$][\\w$]+
+                              (?:\\[\\])?               # {function(string[])} type application, an array of strings
+                              =
+                            )*
+                          )
+                        )
                       )?
-                      \\s*
-                      \\)
+                      \\s*\\)
                     )
                   )
                   (?:                                   # {function(): string} function return type
@@ -2091,46 +2098,53 @@
                   \\s*
                   (?:
                     (?:
-                      \\(
-                      \\s*
+                      \\(\\s*
                       \\.{3}[a-zA-Z_$][\\w$]+           # {function(...string)} variable number of parameters
-                      \\s*
-                      \\)
+                      \\s*\\)
                     )
                     |
                     (?:
-                      \\(
-                      \\s*
+                      \\(\\s*
                       (?:
+                        (?:\\?|!)?                      # {function(?string)} or function(!string)} nullable/non-nullable type
+                        [a-zA-Z_$][\\w$]+
+                        (?:\\[\\])?                     # {function(string[])} type application, an array of strings
                         (?:
                           (?:
-                            \\? |                       # {function(?string)} nullable type
-                            !                           # {function(!string)} non-nullable type
-                          )?
-                          [a-zA-Z_$][\\w$]+
-                          (?:\\[\\])?                   # {function(string[])} type application, an array of strings
-                          (?:
-                            \\s*,\\s*
                             (?:
-                              (?:
-                                (?:
-                                  \\? |                 # {function(string, ?string)} nullable type
-                                  !                     # {function(string, !string)} non-nullable type
-                                )?
-                                [a-zA-Z_$][\\w$]+
-                                (?:\\[\\])?             # {function(string[])} type application, an array of strings
-                              )
-                            )
-                          )*
-                          =?                            # {function(string=)} optional parameter
-                        )+
-                        (?:
-                          \\s*,\\s*
-                          \\.{3}[a-zA-Z_$][\\w$]+       # {function(string, ...string)} variable number of parameters
-                        )?
+                              \\s*,\\s*
+                              (?:\\?|!)?                # {function(?string)} or function(!string)} nullable/non-nullable type
+                              [a-zA-Z_$][\\w$]+
+                              (?:\\[\\])?               # {function(string[])} type application, an array of strings
+                            )*
+                            (?:
+                              \\s*,\\s*
+                              \\.{3}[a-zA-Z_$][\\w$]+   # {function(string, ...string)} variable number of parameters
+                            )?
+                          )
+                          |
+                          (?:
+                            =?                          # {function(string=)} optional parameter
+                            (?:
+                              (?<!=)                    # {function(string, string, number)} loop non-optional params
+                              \\s*,\\s*
+                              (?:\\?|!)?                # {function(?string)} or function(!string)} nullable/non-nullable type
+                              [a-zA-Z_$][\\w$]+
+                              (?:\\[\\])?               # {function(string[])} type application, an array of strings
+                              =?
+                            )*
+                            (?:
+                              (?<==)                    # {function(string, string=, number=)} loop optional params
+                              \\s*,\\s*
+                              (?:\\?|!)?                # {function(?string)} or function(!string)} nullable/non-nullable type
+                              [a-zA-Z_$][\\w$]+
+                              (?:\\[\\])?               # {function(string[])} type application, an array of strings
+                              =
+                            )*
+                          )
+                        )
                       )?
-                      \\s*
-                      \\)
+                      \\s*\\)
                     )
                   )
                   (?:                                   # {function(): string} function return type

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1948,30 +1948,32 @@
                       \\s*
                       (?:
                         (?:
-                          \\? |                         # {function(?string)} nullable type
-                          !   |                         # {function(!string)} non-nullable type
-                        )?
-                        [a-zA-Z_$][\\w$]+
-                        (?:\\[\\])?                     # {function(string[])} type application, an array of strings
-                        (?:
-                          \\s*,\\s*
                           (?:
+                            \\? |                       # {function(?string)} nullable type
+                            !                           # {function(!string)} non-nullable type
+                          )?
+                          [a-zA-Z_$][\\w$]+
+                          (?:\\[\\])?                   # {function(string[])} type application, an array of strings
+                          (?:
+                            \\s*,\\s*
                             (?:
                               (?:
-                                \\? |                   # {function(string, ?string)} nullable type
-                                !   |                   # {function(string, !string)} non-nullable type
-                              )?
-                              [a-zA-Z_$][\\w$]+
-                              (?:\\[\\])?               # {function(string[])} type application, an array of strings
+                                (?:
+                                  \\? |                 # {function(string, ?string)} nullable type
+                                  !                     # {function(string, !string)} non-nullable type
+                                )?
+                                [a-zA-Z_$][\\w$]+
+                                (?:\\[\\])?             # {function(string[])} type application, an array of strings
+                              )
                             )
-                            |
-                            (?:
-                              \\.{3}[a-zA-Z_$][\\w$]+   # {function(string, ...string)} variable number of parameters
-                            )
-                          )
-                        )*
-                        =?                              # {function(string=)} optional parameter
-                      )*
+                          )*
+                          =?                            # {function(string=)} optional parameter
+                        )+
+                        (?:
+                          \\s*,\\s*
+                          \\.{3}[a-zA-Z_$][\\w$]+       # {function(string, ...string)} variable number of parameters
+                        )?
+                      )?
                       \\s*
                       \\)
                     )
@@ -2101,30 +2103,32 @@
                       \\s*
                       (?:
                         (?:
-                          \\? |                         # {function(?string)} nullable type
-                          !   |                         # {function(!string)} non-nullable type
-                        )?
-                        [a-zA-Z_$][\\w$]+
-                        (?:\\[\\])?                     # {function(string[])} type application, an array of strings
-                        (?:
-                          \\s*,\\s*
                           (?:
+                            \\? |                       # {function(?string)} nullable type
+                            !                           # {function(!string)} non-nullable type
+                          )?
+                          [a-zA-Z_$][\\w$]+
+                          (?:\\[\\])?                   # {function(string[])} type application, an array of strings
+                          (?:
+                            \\s*,\\s*
                             (?:
                               (?:
-                                \\? |                   # {function(string, ?string)} nullable type
-                                !   |                   # {function(string, !string)} non-nullable type
-                              )?
-                              [a-zA-Z_$][\\w$]+
-                              (?:\\[\\])?               # {function(string[])} type application, an array of strings
+                                (?:
+                                  \\? |                 # {function(string, ?string)} nullable type
+                                  !                     # {function(string, !string)} non-nullable type
+                                )?
+                                [a-zA-Z_$][\\w$]+
+                                (?:\\[\\])?             # {function(string[])} type application, an array of strings
+                              )
                             )
-                            |
-                            (?:
-                              \\.{3}[a-zA-Z_$][\\w$]+   # {function(string, ...string)} variable number of parameters
-                            )
-                          )
-                        )*
-                        =?                              # {function(string=)} optional parameter
-                      )*
+                          )*
+                          =?                            # {function(string=)} optional parameter
+                        )+
+                        (?:
+                          \\s*,\\s*
+                          \\.{3}[a-zA-Z_$][\\w$]+       # {function(string, ...string)} variable number of parameters
+                        )?
+                      )?
                       \\s*
                       \\)
                     )

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -2037,6 +2037,36 @@ describe "JavaScript grammar", ->
       expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
       expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
+      {tokens} = grammar.tokenizeLine('/** @param {function(...string)} variable this is the description */')
+      expect(tokens[4]).toEqual value: '{function(...string)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {function(string, ...number)} variable this is the description */')
+      expect(tokens[4]).toEqual value: '{function(string, ...number)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {function(string, ...number)} variable this is the description */')
+      expect(tokens[4]).toEqual value: '{function(string, ...number)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {function(!string)} variable this is the description */')
+      expect(tokens[4]).toEqual value: '{function(!string)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {function(?string, !number)} variable this is the description */')
+      expect(tokens[4]).toEqual value: '{function(?string, !number)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {function(string[], number=)} variable this is the description */')
+      expect(tokens[4]).toEqual value: '{function(string[], number=)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
       {tokens} = grammar.tokenizeLine('/** @param {function():number} variable this is the description */')
       expect(tokens[4]).toEqual value: '{function():number}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
       expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
@@ -2090,6 +2120,30 @@ describe "JavaScript grammar", ->
 
       {tokens} = grammar.tokenizeLine('/** @return {function(string, number)} this is the description */')
       expect(tokens[4]).toEqual value: '{function(string, number)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @return {function(...string)} this is the description */')
+      expect(tokens[4]).toEqual value: '{function(...string)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @return {function(string, ...number)} this is the description */')
+      expect(tokens[4]).toEqual value: '{function(string, ...number)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @return {function(string, ...number)} this is the description */')
+      expect(tokens[4]).toEqual value: '{function(string, ...number)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @return {function(!string)} this is the description */')
+      expect(tokens[4]).toEqual value: '{function(!string)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @return {function(?string, !number)} this is the description */')
+      expect(tokens[4]).toEqual value: '{function(?string, !number)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @return {function(string[], number=)} this is the description */')
+      expect(tokens[4]).toEqual value: '{function(string[], number=)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
       expect(tokens[6]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function():number} this is the description */')

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -2047,8 +2047,8 @@ describe "JavaScript grammar", ->
       expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
       expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
-      {tokens} = grammar.tokenizeLine('/** @param {function(string, ...number)} variable this is the description */')
-      expect(tokens[4]).toEqual value: '{function(string, ...number)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      {tokens} = grammar.tokenizeLine('/** @param {function(string, number, ...number)} variable this is the description */')
+      expect(tokens[4]).toEqual value: '{function(string, number, ...number)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
       expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
       expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
@@ -2130,8 +2130,8 @@ describe "JavaScript grammar", ->
       expect(tokens[4]).toEqual value: '{function(string, ...number)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
       expect(tokens[6]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
-      {tokens} = grammar.tokenizeLine('/** @return {function(string, ...number)} this is the description */')
-      expect(tokens[4]).toEqual value: '{function(string, ...number)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      {tokens} = grammar.tokenizeLine('/** @return {function(string, number, ...number)} this is the description */')
+      expect(tokens[4]).toEqual value: '{function(string, number, ...number)}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
       expect(tokens[6]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function(!string)} this is the description */')


### PR DESCRIPTION
This PR adds support for [prefixes and suffixes to the function type params](https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler#variable-parameters) in JSDoc.

Highlighting:
![screen shot 2016-11-15 at 11 51 31](https://cloud.githubusercontent.com/assets/2854338/20304756/ebe94c62-ab29-11e6-97fe-f06330ddea4d.png)
