### PR TITLE
Delete redundant .coffeelintignore file

### DIFF
--- a/.coffeelintignore
+++ b/.coffeelintignore
@@ -1,1 +1,0 @@
-spec/fixtures


### PR DESCRIPTION
Added in 2058cd0, but there isn't a `spec/fixtures` folder (and to my understanding, there never was). This file is just adding clutter.