### PR TITLE
Update javascript.cson to style template strings prefixed with a 'css' tag

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1374,6 +1374,30 @@
         ]
       }
       {
+				'begin': '((\\w+)?(css|CSS|Css))\\s*(`)'
+				'beginCaptures':
+					'1':
+						'name': 'entity.name.function.js'
+					'4':
+						'name': 'punctuation.definition.string.begin.js'
+				'end': '`'
+				'endCaptures':
+					'0':
+						'name': 'punctuation.definition.string.end.js'
+				'name': 'string.quoted.template.css.js'
+				'patterns': [
+					{
+						'include': '#string_escapes'
+					}
+					{
+						'include': '#interpolated_js'
+					}
+					{
+						'include': 'source.css'
+					}
+				]
+			}
+      {
         'begin': '((\\w+)?(html|HTML|Html))\\s*(`)'
         'beginCaptures':
           '1':

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -17,6 +17,8 @@ describe "JavaScript grammar", ->
 
     runs ->
       grammar = atom.grammars.grammarForScopeName("source.js")
+      console.log typeof grammer
+      console.dir grammer
 
   it "parses the grammar", ->
     expect(grammar).toBeTruthy()

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -600,6 +600,35 @@ describe "JavaScript grammar", ->
       expect(tokens[13]).toEqual value: '}', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'punctuation.section.embedded.js']
       expect(tokens[14]).toEqual value: '`', scopes: ['source.js', 'string.quoted.template.js', 'punctuation.definition.string.end.js']
 
+  describe "CSS template strings", ->
+    beforeEach ->
+      waitsForPromise ->
+        atom.packages.activatePackage("language-css")
+
+    it "tokenizes ES6 tagged HTML string templates", ->
+      {tokens} = grammar.tokenizeLine('css`element:hover #id .class [attribute]::before { background: blue; }`')
+      expect(tokens[0]).toEqual value: 'css', scopes: ['source.js', 'string.quoted.template.css.js', 'entity.name.function.js']
+      expect(tokens[1]).toEqual value: '`', scopes: ['source.js', 'string.quoted.template.css.js', 'punctuation.definition.string.begin.js']
+      expect(tokens[2]).toEqual value: 'element', scopes: ['source.css', 'meta.selector.css', 'entity.name.tag.custom.css']
+      expect(tokens[2]).toEqual value: ':', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css', 'punctuation.definition.entity.css']
+      expect(tokens[2]).toEqual value: 'hover', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-class.css']
+      expect(tokens[3]).toEqual value: '#', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.id.css', 'punctuation.definition.entity.css']
+      expect(tokens[4]).toEqual value: 'id', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.id.css']
+      expect(tokens[5]).toEqual value: '.', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.class.css', 'punctuation.definition.entity.css']
+      expect(tokens[6]).toEqual value: 'class', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.class.css']
+      expect(tokens[7]).toEqual value: '[', scopes: ['source.css', 'meta.selector.css', 'meta.attribute-selector.css', 'punctuation.definition.entity.css']
+      expect(tokens[8]).toEqual value: 'attribute', scopes: ['source.css', 'meta.selector.css', 'meta.attribute-selector.css', 'entity.other.attribute-name.css']
+      expect(tokens[9]).toEqual value: ']', scopes: ['source.css', 'meta.selector.css', 'meta.attribute-selector.css', 'punctuation.definition.entity.css']
+      expect(tokens[9]).toEqual value: '::', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-element.css', 'punctuation.definition.entity.css']
+      expect(tokens[9]).toEqual value: 'before', scopes: ['source.css', 'meta.selector.css', 'entity.other.attribute-name.pseudo-element.css']
+      expect(tokens[10]).toEqual value: '{', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.begin.css']
+      expect(tokens[11]).toEqual value: 'background', scopes: ['source.css', 'meta.property-list.css', 'meta.property-name.css', 'support.type.property-name.css']
+      expect(tokens[11]).toEqual value: ':', scopes: ['source.css', 'meta.property-list.css', 'punctuation.separator.key-value.css']
+      expect(tokens[11]).toEqual value: 'blue', scopes: ['source.css', 'meta.property-list.css', 'meta.property-value.css', 'support.constant.property-value.css']
+      expect(tokens[11]).toEqual value: '}', scopes: ['source.css', 'meta.property-list.css', 'punctuation.section.property-list.end.css']
+      expect(tokens[11]).toEqual value: '}', scopes: ['source.css', 'meta.property-list.css', 'punctuation.terminator.rule.css']
+      expect(tokens[12]).toEqual value: '`', scopes: ['source.js', 'string.quoted.template.html.js', 'punctuation.definition.string.end.js']
+
   describe "HTML template strings", ->
     beforeEach ->
       waitsForPromise ->


### PR DESCRIPTION
Currently, when you prefix a template literal with an `html` tag, you get HTML syntax highlighting in that template literal. This doesn't work for CSS. This pull request adds support for CSS syntax highlighting in template literals prefixed with `css`, `CSS`, or `Css`.

Before:
![screen shot 2016-11-28 at 9 29 37 pm](https://cloud.githubusercontent.com/assets/3343902/20696718/404b07ea-b5b2-11e6-8998-fec50d5266d8.png)

After:
![screen shot 2016-11-28 at 9 29 48 pm](https://cloud.githubusercontent.com/assets/3343902/20696720/478b2ab2-b5b2-11e6-83e7-3abc73052276.png)
