### PR TITLE
Allow OpenType ligatures in "double-not" operators

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1307,7 +1307,7 @@
         'name': 'keyword.operator.comparison.js'
       }
       {
-        'match': '&&|!|\\|\\|'
+        'match': '&&|!!|!|\\|\\|'
         'name': 'keyword.operator.logical.js'
       }
       {


### PR DESCRIPTION
This is such a common trick in JavaScript, and it looks pretty nice as a ligature:

<img src="https://cloud.githubusercontent.com/assets/2346707/20867883/73952474-baa2-11e6-94aa-e3a0e49090e5.gif" width="160" alt="!!" />

A patched typeface currently can't target `!!` with a ligature, because each `!` is tokenised separately. The scopes are the same, so there's otherwise no outward difference. For that reason, I've not bothered to include a spec; please advise if you'd like one.