### PR TITLE
Fix various highlighting bugs

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1926,7 +1926,7 @@
                 \\? |                                   # {?string} nullable type
                 !   |                                   # {!string} non-nullable type
                 \\.{3}                                  # {...string} variable number of parameters
-                [*?]?                                   # {...*) Variable number of mixed types
+                [*?]?                                   # {...*} Variable number of mixed types
               )?
 
               (?:
@@ -2055,7 +2055,7 @@
                     "[^"]*"    |                        # [foo="bar"] Double-quoted
                     '[^']*'    |                        # [foo='bar'] Single-quoted
                     {[^{}]*}   |                        # [foo={a:1}] Object literal
-                    \\[ [^\\]\\[]* \\]                  # [foo=[1,2]] Array literal
+                    \\[ [^\\[\\]]* \\]                  # [foo=[1,2]] Array literal
                   )
                 )?
               )
@@ -2100,7 +2100,7 @@
                 \\? |                                   # {?string} nullable type
                 !   |                                   # {!string} non-nullable type
                 \\.{3}                                  # {...string} variable number of parameters
-                [*?]?                                   # {...*) Variable number of mixed types
+                [*?]?                                   # {...*} Variable number of mixed types
               )?
 
               (?:

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -2166,21 +2166,30 @@
                   \\(                                   # Opening bracket of multiple types with parenthesis {(string|number)}
                     [a-zA-Z_$]+
                     (?:
-                      [\\w$]* |
+                      (?:
+                        [\\w$]*
+                        (?:\\[\\])?                     # {(string[]|number)} type application, an array of strings or a number
+                      ) |
                       \\.?<[\\w$]+(?:,\\s+[\\w$]+)*>    # {Array<string>} or {Object<string, number>} type application (optional .)
                     )
                     (?:
                       [\\.|~]                           # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
                       [a-zA-Z_$]+
                       (?:
-                        [\\w$]* |
+                        (?:
+                          [\\w$]*
+                          (?:\\[\\])?                   # {(string|number[])} type application, a string or an array of numbers
+                        ) |
                         \\.?<[\\w$]+(?:,\\s+[\\w$]+)*>  # {Array<string>} or {Object<string, number>} type application (optional .)
                       )
                     )*
                   \\) |
                   [a-zA-Z_$]+
                   (?:
-                    [\\w$]* |
+                    (?:
+                      [\\w$]*
+                      (?:\\[\\])?                       # {(string|number[])} type application, a string or an array of numbers
+                    ) |
                     \\.?<[\\w$]+(?:,\\s+[\\w$]+)*>      # {Array<string>} or {Object<string, number>} type application (optional .)
                   )
                   (?:

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -2053,7 +2053,9 @@
                   (?:
                     [\\w$\\s]* |                        # [foo=bar] Unquoted
                     "[^"]*"    |                        # [foo="bar"] Double-quoted
-                    '[^']*'                             # [foo='bar'] Single-quoted
+                    '[^']*'    |                        # [foo='bar'] Single-quoted
+                    {[^{}]*}   |                        # [foo={a:1}] Object literal
+                    \\[ [^\\]\\[]* \\]                  # [foo=[1,2]] Array literal
                   )
                 )?
               )

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -286,7 +286,7 @@
     ]
   }
   {
-    'match': '(?<!\\.)\\b(?<!\\$)(super|this|arguments)(?!\\s*:|\\$)\\b'
+    'match': '(?:(?<=\\.{3})|(?<!\\.)\\b)(?<!\\$)(super|this|arguments)(?!\\s*:|\\$)\\b'
     'name': 'variable.language.js'
   }
   {

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1926,6 +1926,7 @@
                 \\? |                                   # {?string} nullable type
                 !   |                                   # {!string} non-nullable type
                 \\.{3}                                  # {...string} variable number of parameters
+                [*?]?                                   # {...*) Variable number of mixed types
               )?
 
               (?:
@@ -2097,6 +2098,7 @@
                 \\? |                                   # {?string} nullable type
                 !   |                                   # {!string} non-nullable type
                 \\.{3}                                  # {...string} variable number of parameters
+                [*?]?                                   # {...*) Variable number of mixed types
               )?
 
               (?:

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -2063,6 +2063,54 @@ describe "JavaScript grammar", ->
       expect(tokens[6]).toEqual value: "[ variable = ' default value ' ]", scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
       expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
+      {tokens} = grammar.tokenizeLine('/** @param {Object} [variable={a: "b"}] - An object */')
+      expect(tokens[4]).toEqual value: '{Object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '[variable={a: "b"}]', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[7]).toEqual value: ' - ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc']
+      expect(tokens[8]).toEqual value: 'An object ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {Object} [ variable =  {  a : "b"  } ] - An object */')
+      expect(tokens[4]).toEqual value: '{Object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '[ variable =  {  a : "b"  } ]', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[7]).toEqual value: ' - ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc']
+      expect(tokens[8]).toEqual value: 'An object ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {Array} [variable=[1,2,3]] - An array */')
+      expect(tokens[4]).toEqual value: '{Array}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '[variable=[1,2,3]]', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[7]).toEqual value: ' - ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc']
+      expect(tokens[8]).toEqual value: 'An array ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {Array} [  variable   = [ 1 , 2 , 3  ] ] - An array */')
+      expect(tokens[4]).toEqual value: '{Array}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '[  variable   = [ 1 , 2 , 3  ] ]', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[7]).toEqual value: ' - ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc']
+      expect(tokens[8]).toEqual value: 'An array ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {Object} [variable={}] - Empty object */')
+      expect(tokens[4]).toEqual value: '{Object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '[variable={}]', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[7]).toEqual value: ' - ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc']
+      expect(tokens[8]).toEqual value: 'Empty object ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {Object} [  variable  =  {  }  ] - Empty object */')
+      expect(tokens[4]).toEqual value: '{Object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '[  variable  =  {  }  ]', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[7]).toEqual value: ' - ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc']
+      expect(tokens[8]).toEqual value: 'Empty object ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {Array} [variable=[]] - Empty array */')
+      expect(tokens[4]).toEqual value: '{Array}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '[variable=[]]', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[7]).toEqual value: ' - ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc']
+      expect(tokens[8]).toEqual value: 'Empty array ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {Array} [  variable  =  [  ]  ] - Empty array */')
+      expect(tokens[4]).toEqual value: '{Array}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '[  variable  =  [  ]  ]', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[7]).toEqual value: ' - ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc']
+      expect(tokens[8]).toEqual value: 'Empty array ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
       {tokens} = grammar.tokenizeLine('/** @param {object} variable - this is a {@link linked} description */')
       expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
       expect(tokens[8]).toEqual value: 'this is a ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -305,6 +305,18 @@ describe "JavaScript grammar", ->
       expect(tokens[1]).toEqual value: '...', scopes: ['source.js', 'keyword.operator.spread.js']
       expect(tokens[2]).toEqual value: 'iterableObj', scopes: ['source.js']
 
+      {tokens} = grammar.tokenizeLine('...arguments')
+      expect(tokens[0]).toEqual value: '...', scopes: ['source.js', 'keyword.operator.spread.js']
+      expect(tokens[1]).toEqual value: 'arguments', scopes: ['source.js', 'variable.language.js']
+
+      {tokens} = grammar.tokenizeLine('...super')
+      expect(tokens[0]).toEqual value: '...', scopes: ['source.js', 'keyword.operator.spread.js']
+      expect(tokens[1]).toEqual value: 'super', scopes: ['source.js', 'variable.language.js']
+
+      {tokens} = grammar.tokenizeLine('...this')
+      expect(tokens[0]).toEqual value: '...', scopes: ['source.js', 'keyword.operator.spread.js']
+      expect(tokens[1]).toEqual value: 'this', scopes: ['source.js', 'variable.language.js']
+
     describe "increment, decrement", ->
       it "tokenizes increment", ->
         {tokens} = grammar.tokenizeLine('i++')

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -2182,6 +2182,16 @@ describe "JavaScript grammar", ->
       expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
       expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
+      {tokens} = grammar.tokenizeLine('/** @param {...*} remainder */')
+      expect(tokens[2]).toEqual value: '@param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
+      expect(tokens[4]).toEqual value: '{...*}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'remainder', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {...?} remainder */')
+      expect(tokens[2]).toEqual value: '@param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
+      expect(tokens[4]).toEqual value: '{...?}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'remainder', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+
       {tokens} = grammar.tokenizeLine('/** @param {number=} variable this is the description */')
       expect(tokens[4]).toEqual value: '{number=}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
       expect(tokens[6]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -2349,6 +2349,14 @@ describe "JavaScript grammar", ->
       {tokens} = grammar.tokenizeLine('/** @return {Some|Thing} Something to return */')
       expect(tokens[4]).toEqual value: '{Some|Thing}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
 
+      {tokens} = grammar.tokenizeLine('/** @return {(String[]|Number[])} Description */')
+      expect(tokens[4]).toEqual value: '{(String[]|Number[])}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'Description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {(Number|Number[])} Numbers */')
+      expect(tokens[4]).toEqual value: '{(Number|Number[])}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'Numbers', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+
       {tokens} = grammar.tokenizeLine('/** @return {object} */')
       expect(tokens[4]).toEqual value: '{object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
 


### PR DESCRIPTION
A bunch of mostly JSDoc-related fixes, plus a keyword-highlighting bug I picked up on when subclassing arrays. You can see them all in one picture:

<img src="https://cloud.githubusercontent.com/assets/2346707/21285517/dc85b19c-c48e-11e6-83a7-db18c3ac5cb8.gif" width="370" alt="Figure 1" />

[As you can see](https://cloud.githubusercontent.com/assets/2346707/21285535/290e55c8-c48f-11e6-8c76-77e316668d7f.png), the above code is perfectly legal JSDoc syntax:

<img src="https://cloud.githubusercontent.com/assets/2346707/21285535/290e55c8-c48f-11e6-8c76-77e316668d7f.png" width="370" alt="Figure 2" />