### PR TITLE
Add ternary operator snippet

### DIFF
--- a/snippets/language-javascript.cson
+++ b/snippets/language-javascript.cson
@@ -11,6 +11,9 @@
   'do':
     'prefix': 'do'
     'body': 'do {\n\t$2\n} while (${1:true});'
+  'condition ? true : false':
+    'prefix': 'tern'
+    'body': '${1:condition} ? (${2:true}) : (${3:false})'
   'if':
     'prefix': 'if'
     'body': 'if (${1:true}) {\n\t$2\n}'

--- a/snippets/language-javascript.cson
+++ b/snippets/language-javascript.cson
@@ -13,7 +13,7 @@
     'body': 'do {\n\t$2\n} while (${1:true});'
   'condition ? true : false':
     'prefix': 'tern'
-    'body': '${1:condition} ? (${2:true}) : (${3:false})'
+    'body': '${1:condition} ? ${2:true} : ${3:false}'
   'if':
     'prefix': 'if'
     'body': 'if (${1:true}) {\n\t$2\n}'


### PR DESCRIPTION
Added a ternary operator snippet that can be accessed with `tern`. This are strongly used in react to control the rendering of two components based on a simple condition.