### PR TITLE
Add support for namespaced default values

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -2062,10 +2062,10 @@
                   =                                     # [foo=bar] Default parameter value
                   \\s*
                   (?:
-                    [\\w$\\s]* |                        # [foo=bar] Unquoted
-                    "[^"]*"    |                        # [foo="bar"] Double-quoted
-                    '[^']*'    |                        # [foo='bar'] Single-quoted
-                    {[^{}]*}   |                        # [foo={a:1}] Object literal
+                    [\\w$.\\s]* |                       # [foo=bar] Unquoted
+                    "[^"]*"     |                       # [foo="bar"] Double-quoted
+                    '[^']*'     |                       # [foo='bar'] Single-quoted
+                    {[^{}]*}    |                       # [foo={a:1}] Object literal
                     \\[ [^\\[\\]]* \\]                  # [foo=[1,2]] Array literal
                   )
                 )?

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -1853,6 +1853,11 @@ describe "JavaScript grammar", ->
       expect(tokens[6]).toEqual value: '[ variable = default value ]', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
       expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
 
+      {tokens} = grammar.tokenizeLine '/** @param {object} [variable=default.value] this is the description */'
+      expect(tokens[4]).toEqual value: '{object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '[variable=default.value]', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']
+      expect(tokens[8]).toEqual value: 'this is the description ', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'other.description.jsdoc']
+
       {tokens} = grammar.tokenizeLine('/** @param {object} [variable="default value"] this is the description */')
       expect(tokens[4]).toEqual value: '{object}', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'entity.name.type.instance.jsdoc']
       expect(tokens[6]).toEqual value: '[variable="default value"]', scopes: ['source.js', 'comment.block.documentation.js', 'other.meta.jsdoc', 'variable.other.jsdoc']


### PR DESCRIPTION
Both of these lines are valid JSDoc constructs:

~~~js
/**
 * @param {Object} [name=Default.value]
 * @param {Object} [name=defaultValue]
 */
~~~

A `@param` tag's default-value [accepts anything](http://usejsdoc.org/tags-param.html#multiple-types-and-repeatable-parameters) that a [`@type`](http://usejsdoc.org/tags-type.html) parameter does, so whatever's valid as a `@type` is also valid as a default value:

~~~js
/**
 * @type {Default.value}
 * @type {defaultValue}
*/
~~~