### PR TITLE
Add SJS (server-side JavaScript) to filetypes

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -13,6 +13,7 @@
   'jspre'
   'pac'
   'pjs'
+  'sjs'
   'xsjs'
   'xsjslib'
 ]


### PR DESCRIPTION
### Requirements

I'm working a lot with SJS files. These are JS files that include some additional proprietary APIs that run on the server-side (predating NodeJS). See https://developer.mozilla.org/en-US/docs/Mozilla/httpd.js/HTTP_server_for_unit_tests#SJS:_server-side_scripts for more

### Description of the Change

Added `sjs` to the list of supported filetypes

### Alternate Designs

N/A

### Benefits

Package supports more types of jS

### Possible Drawbacks

sjs is not very widely used. It might overlap with other files that people use in atom?

### Applicable Issues

N/A
