### PR TITLE
Simplify single-line comment handling

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -2269,21 +2269,12 @@
         'name': 'comment.block.js'
       }
       {
-        'begin': '(^[ \\t]+)?(?=//)'
+        'begin': '//'
         'beginCaptures':
-          '1':
-            'name': 'punctuation.whitespace.comment.leading.js'
-        'end': '(?!\\G)'
-        'patterns': [
-          {
-            'begin': '//'
-            'beginCaptures':
-              '0':
-                'name': 'punctuation.definition.comment.js'
-            'end': '\\n'
-            'name': 'comment.line.double-slash.js'
-          }
-        ]
+          '0':
+            'name': 'punctuation.definition.comment.js'
+        'end': '$'
+        'name': 'comment.line.double-slash.js'
       }
     ]
   'switch_statement':

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -833,6 +833,14 @@ describe "JavaScript grammar", ->
       expect(lines[2][2]).toEqual value: ' comment ', scopes: ['source.js', 'meta.import.js', 'comment.block.js']
       expect(lines[2][3]).toEqual value: '*/', scopes: ['source.js', 'meta.import.js', 'comment.block.js', 'punctuation.definition.comment.js']
 
+      # https://github.com/atom/language-javascript/issues/485
+      lines = grammar.tokenizeLines '''
+        import a from 'a'; //
+        import b from 'b';
+      '''
+      expect(lines[0][11]).toEqual value: '//', scopes: ['source.js', 'comment.line.double-slash.js', 'punctuation.definition.comment.js']
+      expect(lines[1][0]).toEqual value: 'import', scopes: ['source.js', 'meta.import.js', 'keyword.control.js']
+
   describe "ES6 export", ->
     it "tokenizes named export", ->
       {tokens} = grammar.tokenizeLine('export var x = 0;')
@@ -1715,6 +1723,14 @@ describe "JavaScript grammar", ->
         expect(tokens[15]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
 
   describe "comments", ->
+    it "tokenizes // comments", ->
+      {tokens} = grammar.tokenizeLine '//'
+      expect(tokens[0]).toEqual value: '//', scopes: ['source.js', 'comment.line.double-slash.js', 'punctuation.definition.comment.js']
+
+      {tokens} = grammar.tokenizeLine '// stuff'
+      expect(tokens[0]).toEqual value: '//', scopes: ['source.js', 'comment.line.double-slash.js', 'punctuation.definition.comment.js']
+      expect(tokens[1]).toEqual value: ' stuff', scopes: ['source.js', 'comment.line.double-slash.js']
+
     it "tokenizes /* */ comments", ->
       {tokens} = grammar.tokenizeLine('/**/')
       expect(tokens[0]).toEqual value: '/*', scopes: ['source.js', 'comment.block.js', 'punctuation.definition.comment.js']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Single-line comments were overcomplicated.  They've been this way at least since the JSON -> CSON conversion.  This PR simplifies them, in the process fixing an import bug, and also adds some basic specs for them.

### Alternate Designs

None.

### Benefits

Easier-to-reason-about code.

### Possible Drawbacks

As far as I can tell, none.

### Applicable Issues

Fixes #485.