### PR TITLE
Add support tagged SQL template strings

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1457,6 +1457,30 @@
         ]
       }
       {
+        'begin': '(sql|SQL|Sql)\\s*(`)'
+        'beginCaptures':
+          '1':
+            'name': 'entity.name.function.js'
+          '2':
+            'name': 'punctuation.definition.string.begin.js'
+        'end': '`'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end.js'
+        'name': 'string.quoted.template.sql.js'
+        'patterns': [
+          {
+            'include': '#string_escapes'
+          }
+          {
+            'include': '#interpolated_js'
+          }
+          {
+            'include': 'source.sql'
+          }
+        ]
+      }
+      {
         'begin': '`'
         'beginCaptures':
           '0':

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -707,6 +707,25 @@ describe "JavaScript grammar", ->
       expect(tokens[6]).toEqual value: ' }', scopes: ['source.js', 'string.quoted.template.graphql.js']
       expect(tokens[7]).toEqual value: '`', scopes: ['source.js', 'string.quoted.template.graphql.js', 'punctuation.definition.string.end.js']
 
+  describe "ES6 tagged SQL string templates", ->
+    it "tokenizes them as strings", ->
+      {tokens} = grammar.tokenizeLine('SQL`SELECT foo FROM bar WHERE id = :id`')
+      expect(tokens[0]).toEqual value: 'SQL', scopes: ['source.js', 'string.quoted.template.sql.js', 'entity.name.function.js']
+      expect(tokens[1]).toEqual value: '`', scopes: ['source.js', 'string.quoted.template.sql.js', 'punctuation.definition.string.begin.js']
+      expect(tokens[2]).toEqual value: 'SELECT foo FROM bar WHERE id = :id', scopes: ['source.js', 'string.quoted.template.sql.js']
+      expect(tokens[3]).toEqual value: '`', scopes: ['source.js', 'string.quoted.template.sql.js', 'punctuation.definition.string.end.js']
+
+  describe "ES6 tagged SQL string templates with interpolation", ->
+    it "tokenizes them as strings", ->
+      {tokens} = grammar.tokenizeLine('SQL`SELECT foo FROM bar WHERE id = ${id}`')
+      expect(tokens[0]).toEqual value: 'SQL', scopes: ['source.js', 'string.quoted.template.sql.js', 'entity.name.function.js']
+      expect(tokens[1]).toEqual value: '`', scopes: ['source.js', 'string.quoted.template.sql.js', 'punctuation.definition.string.begin.js']
+      expect(tokens[2]).toEqual value: 'SELECT foo FROM bar WHERE id = ', scopes: ['source.js', 'string.quoted.template.sql.js']
+      expect(tokens[3]).toEqual value: '${', scopes: ['source.js', 'string.quoted.template.sql.js', 'source.js.embedded.source', 'punctuation.section.embedded.js']
+      expect(tokens[4]).toEqual value: 'id', scopes: ['source.js', 'string.quoted.template.sql.js', 'source.js.embedded.source']
+      expect(tokens[5]).toEqual value: '}', scopes: ['source.js', 'string.quoted.template.sql.js', 'source.js.embedded.source', 'punctuation.section.embedded.js']
+      expect(tokens[6]).toEqual value: '`', scopes: ['source.js', 'string.quoted.template.sql.js', 'punctuation.definition.string.end.js']
+
   describe "ES6 class", ->
     it "tokenizes class", ->
       {tokens} = grammar.tokenizeLine('class MyClass')


### PR DESCRIPTION
### Description of the Change

Added "source.sql" syntax highlighting for SQL tagged strings.

### Alternate Designs

https://github.com/atom/language-php/blob/master/grammars/php.cson#L1614
