### PR TITLE
Added space in function definitions

### DIFF
--- a/snippets/language-javascript.cson
+++ b/snippets/language-javascript.cson
@@ -37,7 +37,7 @@
     'body': 'for (${1:variable} of ${2:iterable}) {\n\t$3\n}'
   'Function':
     'prefix': 'fun'
-    'body': 'function ${1:functionName}($2) {\n\t$0\n}'
+    'body': 'function ${1:functionName} ($2) {\n\t$0\n}'
   'Anonymous Function':
     'prefix': 'f'
     'body': 'function ($1) {\n\t$2\n}'
@@ -46,7 +46,7 @@
     'body': '($1) => {\n\t$2\n}'
   'Generator':
     'prefix': 'gen',
-    'body': 'function* ${1:functionName}($2) {\n\t$0\n}'
+    'body': 'function* ${1:functionName} ($2) {\n\t$0\n}'
   'Anonymous Generator':
     'prefix': 'g'
     'body': 'function* ($1) {\n\t$2\n}'
@@ -70,7 +70,7 @@
     'body': 'querySelectorAll(${1:\'${2:query}\'})$3'
   'Immediately-Invoked Function Expression':
     'prefix': 'iife'
-    'body': '(function() {\n\t${1:\'use strict\';\n}\t$2\n}());'
+    'body': '(function () {\n\t${1:\'use strict\';\n}\t$2\n}());'
   'log':
     'prefix': 'log'
     'body': 'console.log($1);$0'


### PR DESCRIPTION
To be more consistent with the other snippets in this package I've added a space in some function definitions that lacked it.

For example `if (...) {` and `while (...) {` have a space between the keyword and the parenthesis but some function definitions did not and resulted in `function foo() {`.

This behaviour is inconsistent. For example some function definitions did have the space such as:

```
  'Object Method':
    'prefix': 'kf'
    'body': '${1:methodName}: function (${2:attribute}) {\n\t$3\n}${4:,}'
```

Or also:

```
  'Prototype':
    'prefix': 'proto'
    'body': '${1:ClassName}.prototype.${2:methodName} = function ($3) {\n\t$0\n};'
```

But not in:

```
  'Function':
    'prefix': 'fun'
    'body': 'function ${1:functionName}($2) {\n\t$0\n}'
```

With the new changes all function definitions get the space so the result is `function foo () {` and `function () {`.