### PR TITLE
Fixed 'iife' snippet, moving final paren before function invocation

### DIFF
--- a/snippets/language-javascript.cson
+++ b/snippets/language-javascript.cson
@@ -70,7 +70,7 @@
     'body': 'querySelectorAll(${1:\'${2:query}\'})$3'
   'Immediately-Invoked Function Expression':
     'prefix': 'iife'
-    'body': '(function() {\n\t${1:\'use strict\';\n}\t$2\n}());'
+    'body': '(function() {\n\t${1:\'use strict\';\n}\t$2\n})();'
   'log':
     'prefix': 'log'
     'body': 'console.log($1);$0'


### PR DESCRIPTION
This change corrects the 'iife' snippet body. The final parenthesis was in the wrong place: instead of closing the entire expression in the body, it should have been placed before the () function invocation so that the anonymous function gets invoked properly.

