### PR TITLE
return snippet

### DIFF
--- a/snippets/language-javascript.cson
+++ b/snippets/language-javascript.cson
@@ -119,3 +119,6 @@
   'export module':
     'prefix': 'expmod'
     'body': 'module.exports = ${1:name};'
+  'return':
+    'prefix': 'ret'
+    'body': 'return $1;$0'


### PR DESCRIPTION
### Requirements

No one

### Description of the Change

Snippet for `return`. These days is very common to return promises or values (as in functional programming), and I've found very useful the `ret` in language-php snippets

### Alternate Designs

language-php defines other 2 snippets for returning true or false:

```cson
  'return false':
    'prefix': 'ret0'
    'body': 'return false;$0'
  'return true':
    'prefix': 'ret1'
    'body': 'return true;$0'
```

But maybe just one `return $1;` is good enough

### Benefits

New snippet that hope to help everyone

### Possible Drawbacks

No one

### Applicable Issues

At least, no one
