### PR TITLE
Add support for multi-line types in jsdoc.

### DIFF
--- a/grammars/jsdoc.cson
+++ b/grammars/jsdoc.cson
@@ -410,6 +410,10 @@
           }
         ]
       }
+      {
+        'match': '^\\s*\\*(?!/)'
+        'name': 'comment.block.documentation.jsdoc'
+      }
     ]
   'inline-tags':
     'patterns': [
@@ -483,11 +487,6 @@
   # {type}
   'type':
     'patterns': [
-      {
-        # {unclosed
-        'match': '\\G{(?:[^}*]|\\*[^/}])+$'
-        'name': 'invalid.illegal.type.jsdoc'
-      }
       {
         'begin': '\\G({)'
         'beginCaptures':

--- a/spec/jsdoc-spec.coffee
+++ b/spec/jsdoc-spec.coffee
@@ -936,6 +936,36 @@ describe "JSDoc grammar", ->
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
+      {tokens} = grammar.tokenizeLine('/** @param {\nnumber\n} variable this is the description */')
+      expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
+      expect(tokens[6]).toEqual value: '\nnumber\n', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
+      expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {{number}} variable this is the description */')
+      expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
+      expect(tokens[6]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[7]).toEqual value: 'number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[8]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[9]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
+      expect(tokens[11]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {{\n *   number\n * }} variable this is the description */')
+      expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
+      expect(tokens[6]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[8]).toEqual value: ' *', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'comment.block.documentation.jsdoc']
+      expect(tokens[9]).toEqual value: '   number\n', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[10]).toEqual value: ' *', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'comment.block.documentation.jsdoc']
+      expect(tokens[12]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[13]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
+      expect(tokens[15]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
+
+      {tokens} = grammar.tokenizeLine('/** @param {{\n */ foo')
+      expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
+      expect(tokens[6]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[8]).toEqual value: '*/', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.section.end.comment.js']
+      expect(tokens[9]).toEqual value: ' foo', scopes: ['source.js']
+
     it "tokenises @return tags without descriptions", ->
       {tokens} = grammar.tokenizeLine('/** @return {object} */')
       expect(tokens[0]).toEqual value: '/**', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.section.begin.comment.js']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Support for multi line types in jsdoc.
See https://github.com/Microsoft/TypeScript-TmLanguage/issues/467

And here's an example file with multi-line types:
https://github.com/google/closure-library/blob/master/closure/goog/dom/animationframe/animationframe.js#L61

### Alternate Designs

I don't know of any.

### Benefits

Multi line types are correctly highlighted.

### Possible Drawbacks

Unterminated types are not recognized as invalid. I couldn't figure out any way to maintain that. However you can clearly see that the type runs on longer than you're expecting if you forget the closing }, so I don't think that's a major issue.

### Applicable Issues


