### PR TITLE
Add 'dir' snippet

### DIFF
--- a/snippets/language-javascript.cson
+++ b/snippets/language-javascript.cson
@@ -74,6 +74,9 @@
   'log':
     'prefix': 'log'
     'body': 'console.log($1);$0'
+  'dir':
+    'prefix': 'dir'
+    'body': 'console.dir($1);$0'
   'warn':
     'prefix': 'warn'
     'body': 'console.warn($1);$0'


### PR DESCRIPTION
### Description of the Change
Added a new `dir` snippet.

### Alternate Designs
No alternates.

### Benefits
Studying and writing JavaScript means frequently use of console. And simple `console.log()` is not always enough to catch anyoing bug or figure out what's going on in your code. I myself often have to use `console.dir()` and frankly speaking i'm tired of typing this every time. So, here is the solution.

### Possible Drawbacks
No, just a new snippet.

### Applicable Issues
Didn't find any of them.
