### PR TITLE
Update JSDoc grammar with recent additions

### DIFF
--- a/grammars/jsdoc.cson
+++ b/grammars/jsdoc.cson
@@ -401,10 +401,10 @@
       |exports?|extends|extension(?:_?for)?|external|externs|file|fileoverview|final|fires|for|func
       |function|global|host|ignore|implements|implicitCast|inherit[Dd]oc|inner|instance|interface
       |internal|kind|lends|license|listens|main|member|memberof!?|method|mixes|mixins?|modifies|module
-      |name|namespace|noalias|nocollapse|nocompile|nosideeffects|override|overview|package|param|preserve
-      |private|prop|property|protected|public|read[Oo]nly|record|require[ds]|returns?|see|since|static
-      |struct|submodule|summary|suppress|template|this|throws|todo|tutorial|type|typedef|unrestricted
-      |uses|var|variation|version|virtual|writeOnce)
+      |name|namespace|noalias|nocollapse|nocompile|nosideeffects|override|overview|package|param
+      |polymer(?:Behavior)?|preserve|private|prop|property|protected|public|read[Oo]nly|record
+      |require[ds]|returns?|see|since|static|struct|submodule|summary|suppress|template|this
+      |throws|todo|tutorial|type|typedef|unrestricted|uses|var|variation|version|virtual|writeOnce)
       \\b
     '''
     'name': 'storage.type.class.jsdoc'

--- a/grammars/jsdoc.cson
+++ b/grammars/jsdoc.cson
@@ -311,7 +311,14 @@
   {
     # Tags followed by a type expression
     # -  @<tag> {type}
-    'begin': '((@)(?:define|enum|exception|implements|modifies|namespace|private|protected|returns?|suppress|throws|type))\\s+(?={)'
+    'begin': '''(?x)
+    (
+      (@)
+      (?:define|enum|exception|export|extends|lends|implements|modifies
+      |namespace|private|protected|returns?|suppress|this|throws|type)
+    )
+    \\s+(?={)
+    '''
     'beginCaptures':
       '1':
         'name': 'storage.type.class.jsdoc'

--- a/grammars/jsdoc.cson
+++ b/grammars/jsdoc.cson
@@ -315,7 +315,8 @@
     (
       (@)
       (?:define|enum|exception|export|extends|lends|implements|modifies
-      |namespace|private|protected|returns?|suppress|this|throws|type)
+      |namespace|private|protected|returns?|suppress|this|throws|type
+      |yields?)
     )
     \\s+(?={)
     '''
@@ -406,12 +407,13 @@
       |callback|chainable|class|classdesc|code|config|const|constant|constructor|constructs|copyright
       |default|defaultvalue|define|deprecated|desc|description|dict|emits|enum|event|example|exception
       |exports?|extends|extension(?:_?for)?|external|externs|file|fileoverview|final|fires|for|func
-      |function|global|host|ignore|implements|implicitCast|inherit[Dd]oc|inner|instance|interface
-      |internal|kind|lends|license|listens|main|member|memberof!?|method|mixes|mixins?|modifies|module
-      |name|namespace|noalias|nocollapse|nocompile|nosideeffects|override|overview|package|param
-      |polymer(?:Behavior)?|preserve|private|prop|property|protected|public|read[Oo]nly|record
-      |require[ds]|returns?|see|since|static|struct|submodule|summary|suppress|template|this
-      |throws|todo|tutorial|type|typedef|unrestricted|uses|var|variation|version|virtual|writeOnce)
+      |function|generator|global|hideconstructor|host|ignore|implements|implicitCast|inherit[Dd]oc
+      |inner|instance|interface|internal|kind|lends|license|listens|main|member|memberof!?|method
+      |mixes|mixins?|modifies|module|name|namespace|noalias|nocollapse|nocompile|nosideeffects
+      |override|overview|package|param|polymer(?:Behavior)?|preserve|private|prop|property|protected
+      |public|read[Oo]nly|record|require[ds]|returns?|see|since|static|struct|submodule|summary
+      |suppress|template|this|throws|todo|tutorial|type|typedef|unrestricted|uses|var|variation
+      |version|virtual|writeOnce|yields?)
       \\b
     '''
     'name': 'storage.type.class.jsdoc'


### PR DESCRIPTION
This PR updates the [JSDoc grammar](https://github.com/atom/language-javascript/blob/23fac44/grammars/jsdoc.cson) with new tags added in v3.5.0, and also fixes a few omissions for Closure Compiler related stuff.

The notes of each commit contain details and references:

* [[`7c0699f2e`](https://github.com/atom/language-javascript/commit/753cb5d8aff676d5bff684bb59b1c04)] Add `@polymer` and `@polymerBehavior` JSDoc tags
* [[`6685c1a9c`](https://github.com/atom/language-javascript/commit/6685c1a9c60c60681e865f622f7fea4a8fa58e63)] Allow curly brackets to be used in some JSDoc tags
* [[`1524164e5`](https://github.com/atom/language-javascript/commit/1524164e55879f23a6429941422906fd5bfcebb9)] Add support for JSDoc 3.5.0 tags