### PR TITLE
Hide RegExp-specific grammars from selection menu

### DIFF
--- a/grammars/regular expression replacement (javascript).cson
+++ b/grammars/regular expression replacement (javascript).cson
@@ -1,6 +1,4 @@
 'scopeName': 'source.js.regexp.replacement'
-'name': 'Regular Expression Replacement (JavaScript)'
-'fileTypes': []
 'patterns': [
   {
     'include': '#regexp-replacement'

--- a/grammars/regular expressions (javascript).cson
+++ b/grammars/regular expressions (javascript).cson
@@ -1,6 +1,4 @@
 'scopeName': 'source.js.regexp'
-'name': 'Regular Expressions (JavaScript)'
-'fileTypes': []
 'patterns': [
   {
     'include': '#regexp'


### PR DESCRIPTION
This PR is a follow-up of [`atom/grammar-selector#34`](https://github.com/atom/grammar-selector/pull/34), which patched the grammar selection menu to hide grammars without a defined `name` field. Refer to the PR for rationale and prior discussion.

This package contains two grammars which are (as far as I can tell) only used by `find-and-replace` to highlight input fields when the regex option is active. This should be enough to declare them "internal-use only".

I left JSDoc alone because I'm not 100% sure whether hiding it is the right thing to do. Yes, the JSDoc grammar *is* used indirectly in the same way other "internal-use only" grammars are... however, its presence in the menu is far from conspicuous, as JSDoc is well-known to any JS dev worth their salt. I'll leave it to you to decide whether it should be hidden or not.

/cc @50Wliu

**Related pull-requests:**
- [`atom/language-hyperlink#18`](https://github.com/atom/language-hyperlink/pull/18)
- [`atom/language-todo#65`](https://github.com/atom/language-todo/pull/65)