### PR TITLE
Allow spreads to precede the `await` operator

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -951,7 +951,11 @@
     'name': 'meta.control.yield.js'
   }
   {
-    'match': '(?<!\\.)\\b(await|break|catch|continue|do|else|finally|for|if|import|package|return|throw|try|while|with)(?!\\s*:)\\b'
+    'match': '(?:(?<=\\.{3})|(?<!\\.))\\b(await)(?!\\s*:)\\b'
+    'name': 'keyword.control.js'
+  }
+  {
+    'match': '(?<!\\.)\\b(break|catch|continue|do|else|finally|for|if|import|package|return|throw|try|while|with)(?!\\s*:)\\b'
     'name': 'keyword.control.js'
   }
   {

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -120,6 +120,14 @@ describe "JavaScript grammar", ->
       expect(tokens[0]).toEqual value: "debugger", scopes: ['source.js', 'keyword.other.debugger.js']
       expect(tokens[1]).toEqual value: ";", scopes: ['source.js', 'punctuation.terminator.statement.js']
 
+    it "tokenises an `await` keyword after a spread operator", ->
+      {tokens} = grammar.tokenizeLine("...await stuff()")
+      expect(tokens[0]).toEqual value: '...', scopes: ['source.js', 'keyword.operator.spread.js']
+      expect(tokens[1]).toEqual value: 'await', scopes: ['source.js', 'keyword.control.js']
+      expect(tokens[3]).toEqual value: 'stuff', scopes: ['source.js', 'meta.function-call.js', 'entity.name.function.js']
+      expect(tokens[4]).toEqual value: '(', scopes: ['source.js', 'meta.function-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
+      expect(tokens[5]).toEqual value: ')', scopes: ['source.js', 'meta.function-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
+
   describe "built-in globals", ->
     it "tokenizes built-in classes", ->
       {tokens} = grammar.tokenizeLine('window')


### PR DESCRIPTION
### Description of the Change

This is legal JS:

~~~js
async function filter(list){
	list = doStuff(...await parseList(list));
}
~~~

Currently, `...await` isn't receiving correct highlighting and requires an intervening space character in order for `await` to be scoped properly. This PR fixes that.