### PR TITLE
Mark type contents with meta.embedded scope

### DIFF
--- a/grammars/jsdoc.cson
+++ b/grammars/jsdoc.cson
@@ -502,18 +502,15 @@
         'name': 'invalid.illegal.type.jsdoc'
       }
       {
+        'name': 'entity.name.type.instance.jsdoc'
         'begin': '\\G({)'
         'beginCaptures':
-          '0':
-            'name': 'entity.name.type.instance.jsdoc'
           '1':
             'name': 'punctuation.definition.bracket.curly.begin.jsdoc'
-        'contentName': 'entity.name.type.instance.jsdoc.meta.embedded'
-        'end': '((}))\\s*|(?=\\*/)'
+        'contentName': 'meta.embedded.line.js.jsdoc.type'
+        'end': '(})\\s*|(?=\\*/)'
         'endCaptures':
           '1':
-            'name': 'entity.name.type.instance.jsdoc'
-          '2':
             'name': 'punctuation.definition.bracket.curly.end.jsdoc'
         'patterns': [
           {

--- a/grammars/jsdoc.cson
+++ b/grammars/jsdoc.cson
@@ -508,7 +508,7 @@
             'name': 'entity.name.type.instance.jsdoc'
           '1':
             'name': 'punctuation.definition.bracket.curly.begin.jsdoc'
-        'contentName': 'entity.name.type.instance.jsdoc'
+        'contentName': 'entity.name.type.instance.jsdoc.meta.embedded'
         'end': '((}))\\s*|(?=\\*/)'
         'endCaptures':
           '1':

--- a/spec/jsdoc-spec.coffee
+++ b/spec/jsdoc-spec.coffee
@@ -80,7 +80,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' - this is a ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -94,7 +94,7 @@ describe "JSDoc grammar", ->
 
       {tokens} = grammar.tokenizeLine('/** @param {object} variable - this is a {@link linked#description}. */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' - this is a ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -108,7 +108,7 @@ describe "JSDoc grammar", ->
 
       {tokens} = grammar.tokenizeLine('/** @param {object} variable - this is a [description with a]{@link example}. */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' - this is a ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -129,7 +129,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'EntityType', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'EntityType', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
       expect(tokens[10]).toEqual value: 'typeHint', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -213,16 +213,16 @@ describe "JSDoc grammar", ->
       expect(tokens[3]).toEqual value: 'const', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[4]).toEqual value: ' ', scopes: ['source.js', 'comment.block.documentation.js']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
-      expect(tokens[8]).toEqual value: ' ', scopes: ['source.js', 'comment.block.documentation.js']
+      expect(tokens[8]).toEqual value: ' ', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
       expect(tokens[9]).toEqual value: '*/', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.definition.comment.end.js']
 
       {tokens} = grammar.tokenizeLine('/** @define {object} */')
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'define', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
     it "tokenises unnamed @param tags", ->
@@ -232,9 +232,9 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
-      expect(tokens[8]).toEqual value: ' ', scopes: ['source.js', 'comment.block.documentation.js']
+      expect(tokens[8]).toEqual value: ' ', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
       expect(tokens[9]).toEqual value: '*/', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.definition.comment.end.js']
 
     it "tokenises @param tags", ->
@@ -243,7 +243,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[11]).toEqual value: '*/', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.definition.comment.end.js']
@@ -254,7 +254,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -265,7 +265,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'arg', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -276,7 +276,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'argument', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -287,7 +287,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' - this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -298,7 +298,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: '$variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -310,7 +310,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
       expect(tokens[10]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -329,7 +329,7 @@ describe "JSDoc grammar", ->
       it "tokenises unquoted values", ->
         {tokens} = grammar.tokenizeLine('/** @param {object} [variable=default value] this is the description */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -340,7 +340,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine('/** @param {object} [variable = default value] this is the description */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'variable ', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -351,7 +351,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine('/** @param {object} [ variable = default value ] this is the description */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: ' variable ', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -364,7 +364,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine('/** @param {object} [variable=default.value] this is the description */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -378,7 +378,7 @@ describe "JSDoc grammar", ->
       it "tokenises quoted values", ->
         {tokens} = grammar.tokenizeLine('/** @param {object} [variable="default value"] this is the description */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -391,7 +391,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine('/** @param {object} [variable = "default value"] this is the description */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'variable ', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -404,7 +404,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine('/** @param {object} [ variable = " default value " ] this is the description */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: ' variable ', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -417,7 +417,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine("/** @param {object} [variable='default value'] this is the description */")
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -430,7 +430,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine("/** @param {object} [variable = 'default value'] this is the description */")
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'variable ', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -443,7 +443,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine("/** @param {object} [ variable = ' default value ' ] this is the description */")
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: ' variable ', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -457,7 +457,7 @@ describe "JSDoc grammar", ->
       it "tokenises object literals", ->
         {tokens} = grammar.tokenizeLine('/** @param {Object} [variable={a: "b"}] - An object */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -474,7 +474,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine('/** @param {Object} [ variable =  {  a : "b"  } ] - An object */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: ' variable ', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -491,7 +491,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine('/** @param {Object} [variable={}] - Empty object */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -503,7 +503,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine('/** @param {Object} [  variable  =  {  }  ] - Empty object */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: '  variable  ', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -516,7 +516,7 @@ describe "JSDoc grammar", ->
       it "tokenises arrays", ->
         {tokens} = grammar.tokenizeLine('/** @param {Array} [variable=[1,2,3]] - An array */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'Array', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+        expect(tokens[6]).toEqual value: 'Array', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -533,7 +533,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine('/** @param {Array} [  variable   = [ 1 , 2 , 3  ] ] - An array */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'Array', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+        expect(tokens[6]).toEqual value: 'Array', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: '  variable   ', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -550,7 +550,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine('/** @param {Array} [variable=[]] - Empty array */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'Array', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+        expect(tokens[6]).toEqual value: 'Array', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -562,7 +562,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine('/** @param {Array} [  variable  =  [  ]  ] - Empty array */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'Array', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+        expect(tokens[6]).toEqual value: 'Array', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: '  variable  ', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -578,7 +578,7 @@ describe "JSDoc grammar", ->
         expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
         expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'thing', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -613,7 +613,7 @@ describe "JSDoc grammar", ->
         expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
         expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'thing', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -649,7 +649,7 @@ describe "JSDoc grammar", ->
         expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
         expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'thing', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -666,7 +666,7 @@ describe "JSDoc grammar", ->
         expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
         expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'thing', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -697,7 +697,7 @@ describe "JSDoc grammar", ->
         expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
         expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'String', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+        expect(tokens[6]).toEqual value: 'String', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'key', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -715,7 +715,7 @@ describe "JSDoc grammar", ->
         expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
         expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'String', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+        expect(tokens[6]).toEqual value: 'String', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'key', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -731,14 +731,14 @@ describe "JSDoc grammar", ->
     it "tokenises @param tags with accessor-style names", ->
       {tokens} = grammar.tokenizeLine('/** @param {object} parameter.property this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'parameter.property', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
 
       {tokens} = grammar.tokenizeLine('/** @param {object} [parameter.property] this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
       expect(tokens[10]).toEqual value: 'parameter.property', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -747,7 +747,7 @@ describe "JSDoc grammar", ->
 
       {tokens} = grammar.tokenizeLine('/** @param {object} [ parameter.property ] this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
       expect(tokens[10]).toEqual value: ' parameter.property ', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -756,7 +756,7 @@ describe "JSDoc grammar", ->
 
       {tokens} = grammar.tokenizeLine('/** @param {object} [parameter.property=default value] this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
       expect(tokens[10]).toEqual value: 'parameter.property', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -767,7 +767,7 @@ describe "JSDoc grammar", ->
 
       {tokens} = grammar.tokenizeLine('/** @param {object} [parameter.property = default value] this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
       expect(tokens[10]).toEqual value: 'parameter.property ', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -779,7 +779,7 @@ describe "JSDoc grammar", ->
 
       {tokens} = grammar.tokenizeLine('/** @param {object} [ parameter.property = default value ] this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
       expect(tokens[10]).toEqual value: ' parameter.property ', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -793,13 +793,13 @@ describe "JSDoc grammar", ->
     it "tokenises @param tags with wildcard types", ->
       {tokens} = grammar.tokenizeLine('/** @param {*} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '*', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: '*', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
       {tokens} = grammar.tokenizeLine('/** @param {?} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '?', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: '?', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -810,7 +810,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'myNamespace.MyClass', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'myNamespace.MyClass', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -821,7 +821,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'Foo~cb', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'Foo~cb', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -830,7 +830,7 @@ describe "JSDoc grammar", ->
     it "tokenises @param tags with multiple types", ->
       {tokens} = grammar.tokenizeLine('/** @param {function|string} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function|string', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function|string', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -840,26 +840,26 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'string', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[9]).toEqual value: '|number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'string', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[9]).toEqual value: '|number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[10]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[12]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[13]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
 
       {tokens} = grammar.tokenizeLine('/** @param {string|number[]} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'string|number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'string|number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[9]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[11]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {(number|function)} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '(number|function)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: '(number|function)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -869,10 +869,10 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '(string', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[9]).toEqual value: '|number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: '(string', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[9]).toEqual value: '|number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[10]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[12]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[13]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -880,10 +880,10 @@ describe "JSDoc grammar", ->
 
       {tokens} = grammar.tokenizeLine('/** @param {(string|number[])} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '(string|number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[9]).toEqual value: ')', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: '(string|number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[9]).toEqual value: ')', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[10]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[12]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[13]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -893,7 +893,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '?number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: '?number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
@@ -901,7 +901,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '!number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: '!number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
@@ -909,7 +909,7 @@ describe "JSDoc grammar", ->
       {tokens} = grammar.tokenizeLine('/** @param {...number} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '...number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: '...number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
@@ -918,7 +918,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '...*', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: '...*', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'remainder', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[11]).toEqual value: '*/', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.definition.comment.end.js']
@@ -928,7 +928,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '...?', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: '...?', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'remainder', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[11]).toEqual value: '*/', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.definition.comment.end.js']
@@ -936,16 +936,16 @@ describe "JSDoc grammar", ->
     it "tokenises @param tags using Google Closure Compiler syntax", ->
       {tokens} = grammar.tokenizeLine('/** @param {number=} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'number=', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'number=', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {number[]} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[9]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[11]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
@@ -954,10 +954,10 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'Foo', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[9]).toEqual value: '.bar', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'Foo', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[9]).toEqual value: '.bar', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[10]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[12]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[13]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -966,14 +966,14 @@ describe "JSDoc grammar", ->
       {tokens} = grammar.tokenizeLine('/** @param {Array<number>} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'Array<number>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'Array<number>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {Array.<number>} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'Array.<number>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'Array.<number>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -981,7 +981,7 @@ describe "JSDoc grammar", ->
       {tokens} = grammar.tokenizeLine('/** @param {Array<number>|Array<string>} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'Array<number>|Array<string>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'Array<number>|Array<string>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -989,21 +989,21 @@ describe "JSDoc grammar", ->
       {tokens} = grammar.tokenizeLine('/** @param {Array.<number>|Array.<string>} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'Array.<number>|Array.<string>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'Array.<number>|Array.<string>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {(Array<number>|Array<string>)} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '(Array<number>|Array<string>)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: '(Array<number>|Array<string>)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {(Array.<number>|Array.<string>)} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '(Array.<number>|Array.<string>)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: '(Array.<number>|Array.<string>)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -1011,7 +1011,7 @@ describe "JSDoc grammar", ->
       {tokens} = grammar.tokenizeLine('/** @param {Object<string, number>} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'Object<string, number>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'Object<string, number>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -1019,7 +1019,7 @@ describe "JSDoc grammar", ->
       {tokens} = grammar.tokenizeLine('/** @param {Object.<string, number>} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'Object.<string, number>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'Object.<string, number>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -1027,7 +1027,7 @@ describe "JSDoc grammar", ->
       {tokens} = grammar.tokenizeLine('/** @param {Object<string, number>|Array<number>} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'Object<string, number>|Array<number>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'Object<string, number>|Array<number>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -1035,7 +1035,7 @@ describe "JSDoc grammar", ->
       {tokens} = grammar.tokenizeLine('/** @param {Object.<string, number>|Array.<number>} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'Object.<string, number>|Array.<number>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'Object.<string, number>|Array.<number>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -1043,105 +1043,105 @@ describe "JSDoc grammar", ->
       {tokens} = grammar.tokenizeLine('/** @param {(Array<number>|Object<string, number>)} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '(Array<number>|Object<string, number>)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: '(Array<number>|Object<string, number>)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {(Array.<number>|Object.<string, number>)} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '(Array.<number>|Object.<string, number>)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: '(Array.<number>|Object.<string, number>)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function()} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function()', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function()', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function ()} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function ()', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function ()', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function ( )} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function ( )', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function ( )', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function(string)} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function(string)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function(string, number)} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string, number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function(string, number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function(...string)} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(...string)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function(...string)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function(string, ...number)} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string, ...number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function(string, ...number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function(string, number, ...number)} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string, number, ...number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function(string, number, ...number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function(!string)} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(!string)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function(!string)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function(?string, !number)} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(?string, !number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function(?string, !number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function(string[], number=)} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[9]).toEqual value: ', number=)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function(string', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[9]).toEqual value: ', number=)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[10]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[12]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function():number} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function():number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function():number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function(string): number} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string): number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function(string): number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function(string) : number} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string) : number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function(string) : number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
@@ -1151,7 +1151,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'return', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: '*/', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.definition.comment.end.js']
 
@@ -1160,7 +1160,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'returns', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: '*/', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.definition.comment.end.js']
 
@@ -1170,7 +1170,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'returns', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'this', scopes: ['source.js', 'comment.block.documentation.js']
       expect(tokens[10]).toEqual value: ' is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -1181,7 +1181,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'return', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'this', scopes: ['source.js', 'comment.block.documentation.js']
       expect(tokens[10]).toEqual value: ' is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -1190,14 +1190,14 @@ describe "JSDoc grammar", ->
       {tokens} = grammar.tokenizeLine('/** @returns {(Something)} */')
       expect(tokens[3]).toEqual value: 'returns', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '(Something)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: '(Something)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
     it "tokenises @return tags with multiple types", ->
       {tokens} = grammar.tokenizeLine('/** @return {Some|Thing} Something to return */')
       expect(tokens[3]).toEqual value: 'return', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'Some|Thing', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'Some|Thing', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {(String[]|Number[])} Description */')
@@ -1205,13 +1205,13 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'return', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '(String', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[9]).toEqual value: '|Number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[10]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[11]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[12]).toEqual value: ')', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: '(String', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[9]).toEqual value: '|Number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[10]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[11]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[12]).toEqual value: ')', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[13]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[15]).toEqual value: 'Description', scopes: ['source.js', 'comment.block.documentation.js']
       expect(tokens[17]).toEqual value: '*/', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.definition.comment.end.js']
@@ -1221,78 +1221,78 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'return', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function()', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function()', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function ()} this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function ()', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function ()', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function ( )} this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function ( )', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function ( )', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function(string)} this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function(string)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function(string, number)} this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string, number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function(string, number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function(...string)} this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(...string)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function(...string)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function(string, ...number)} this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string, ...number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function(string, ...number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function(string, number, ...number)} this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string, number, ...number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function(string, number, ...number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function(!string)} this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(!string)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function(!string)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function(?string, !number)} this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(?string, !number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function(?string, !number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function(string[], number=)} this is the description */')
       expect(tokens[3]).toEqual value: 'return', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
-      expect(tokens[9]).toEqual value: ', number=)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function(string', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
+      expect(tokens[9]).toEqual value: ', number=)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[10]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function():number} this is the description */')
       expect(tokens[3]).toEqual value: 'return', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function():number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function():number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function(string): number} this is the description */')
       expect(tokens[3]).toEqual value: 'return', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string): number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function(string): number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function(string) : number} this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string) : number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'function(string) : number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
   describe "highlighted JavaScript examples", ->
@@ -1415,9 +1415,9 @@ describe "JSDoc grammar", ->
       expect(lines[3][1]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(lines[3][2]).toEqual value: 'return', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(lines[3][4]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(lines[3][5]).toEqual value: 'String', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(lines[3][5]).toEqual value: 'String', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(lines[3][6]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
-      expect(lines[3][7]).toEqual value: '', scopes: ['source.js', 'comment.block.documentation.js']
+      expect(lines[3][7]).toEqual value: '', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
       expect(lines[4][1]).toEqual value: '*/', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.definition.comment.end.js']
 
 
@@ -1428,7 +1428,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'String ', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'String ', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '*/', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.definition.comment.end.js']
       expect(tokens[8]).toEqual value: ' aa', scopes: ['source.js']
 
@@ -1437,7 +1437,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '*', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: '*', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
       expect(tokens[10]).toEqual value: 'name', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -1463,7 +1463,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'string="Foo', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'string="Foo', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '*/', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.definition.comment.end.js']
       expect(tokens[8]).toEqual value: 'oo', scopes: ['source.js']
       expect(tokens[9]).toEqual value: '"', scopes: ['source.js', 'string.quoted.double.js', 'punctuation.definition.string.begin.js']
@@ -1507,7 +1507,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'Something', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[6]).toEqual value: 'Something', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'meta.embedded.line.js.jsdoc.type']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
       expect(tokens[10]).toEqual value: 'value', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']

--- a/spec/jsdoc-spec.coffee
+++ b/spec/jsdoc-spec.coffee
@@ -80,7 +80,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' - this is a ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -94,7 +94,7 @@ describe "JSDoc grammar", ->
 
       {tokens} = grammar.tokenizeLine('/** @param {object} variable - this is a {@link linked#description}. */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' - this is a ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -108,7 +108,7 @@ describe "JSDoc grammar", ->
 
       {tokens} = grammar.tokenizeLine('/** @param {object} variable - this is a [description with a]{@link example}. */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' - this is a ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -129,7 +129,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'EntityType', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'EntityType', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
       expect(tokens[10]).toEqual value: 'typeHint', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -213,7 +213,7 @@ describe "JSDoc grammar", ->
       expect(tokens[3]).toEqual value: 'const', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[4]).toEqual value: ' ', scopes: ['source.js', 'comment.block.documentation.js']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[8]).toEqual value: ' ', scopes: ['source.js', 'comment.block.documentation.js']
       expect(tokens[9]).toEqual value: '*/', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.definition.comment.end.js']
@@ -222,7 +222,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'define', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
     it "tokenises unnamed @param tags", ->
@@ -232,7 +232,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[8]).toEqual value: ' ', scopes: ['source.js', 'comment.block.documentation.js']
       expect(tokens[9]).toEqual value: '*/', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.definition.comment.end.js']
@@ -243,7 +243,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[11]).toEqual value: '*/', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.definition.comment.end.js']
@@ -254,7 +254,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -265,7 +265,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'arg', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -276,7 +276,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'argument', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -287,7 +287,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' - this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -298,7 +298,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: '$variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -310,7 +310,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
       expect(tokens[10]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -329,7 +329,7 @@ describe "JSDoc grammar", ->
       it "tokenises unquoted values", ->
         {tokens} = grammar.tokenizeLine('/** @param {object} [variable=default value] this is the description */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -340,7 +340,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine('/** @param {object} [variable = default value] this is the description */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'variable ', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -351,7 +351,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine('/** @param {object} [ variable = default value ] this is the description */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: ' variable ', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -364,7 +364,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine('/** @param {object} [variable=default.value] this is the description */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -378,7 +378,7 @@ describe "JSDoc grammar", ->
       it "tokenises quoted values", ->
         {tokens} = grammar.tokenizeLine('/** @param {object} [variable="default value"] this is the description */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -391,7 +391,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine('/** @param {object} [variable = "default value"] this is the description */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'variable ', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -404,7 +404,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine('/** @param {object} [ variable = " default value " ] this is the description */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: ' variable ', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -417,7 +417,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine("/** @param {object} [variable='default value'] this is the description */")
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -430,7 +430,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine("/** @param {object} [variable = 'default value'] this is the description */")
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'variable ', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -443,7 +443,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine("/** @param {object} [ variable = ' default value ' ] this is the description */")
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+        expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: ' variable ', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -457,7 +457,7 @@ describe "JSDoc grammar", ->
       it "tokenises object literals", ->
         {tokens} = grammar.tokenizeLine('/** @param {Object} [variable={a: "b"}] - An object */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -474,7 +474,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine('/** @param {Object} [ variable =  {  a : "b"  } ] - An object */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: ' variable ', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -491,7 +491,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine('/** @param {Object} [variable={}] - Empty object */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -503,7 +503,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine('/** @param {Object} [  variable  =  {  }  ] - Empty object */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: '  variable  ', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -516,7 +516,7 @@ describe "JSDoc grammar", ->
       it "tokenises arrays", ->
         {tokens} = grammar.tokenizeLine('/** @param {Array} [variable=[1,2,3]] - An array */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'Array', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+        expect(tokens[6]).toEqual value: 'Array', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -533,7 +533,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine('/** @param {Array} [  variable   = [ 1 , 2 , 3  ] ] - An array */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'Array', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+        expect(tokens[6]).toEqual value: 'Array', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: '  variable   ', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -550,7 +550,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine('/** @param {Array} [variable=[]] - Empty array */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'Array', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+        expect(tokens[6]).toEqual value: 'Array', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -562,7 +562,7 @@ describe "JSDoc grammar", ->
 
         {tokens} = grammar.tokenizeLine('/** @param {Array} [  variable  =  [  ]  ] - Empty array */')
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'Array', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+        expect(tokens[6]).toEqual value: 'Array', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: '  variable  ', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -578,7 +578,7 @@ describe "JSDoc grammar", ->
         expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
         expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'thing', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -613,7 +613,7 @@ describe "JSDoc grammar", ->
         expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
         expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'thing', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -649,7 +649,7 @@ describe "JSDoc grammar", ->
         expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
         expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'thing', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -666,7 +666,7 @@ describe "JSDoc grammar", ->
         expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
         expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+        expect(tokens[6]).toEqual value: 'Object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'thing', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -697,7 +697,7 @@ describe "JSDoc grammar", ->
         expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
         expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'String', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+        expect(tokens[6]).toEqual value: 'String', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'key', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -715,7 +715,7 @@ describe "JSDoc grammar", ->
         expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
         expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
         expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-        expect(tokens[6]).toEqual value: 'String', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+        expect(tokens[6]).toEqual value: 'String', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
         expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
         expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
         expect(tokens[10]).toEqual value: 'key', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -731,14 +731,14 @@ describe "JSDoc grammar", ->
     it "tokenises @param tags with accessor-style names", ->
       {tokens} = grammar.tokenizeLine('/** @param {object} parameter.property this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'parameter.property', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
 
       {tokens} = grammar.tokenizeLine('/** @param {object} [parameter.property] this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
       expect(tokens[10]).toEqual value: 'parameter.property', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -747,7 +747,7 @@ describe "JSDoc grammar", ->
 
       {tokens} = grammar.tokenizeLine('/** @param {object} [ parameter.property ] this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
       expect(tokens[10]).toEqual value: ' parameter.property ', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -756,7 +756,7 @@ describe "JSDoc grammar", ->
 
       {tokens} = grammar.tokenizeLine('/** @param {object} [parameter.property=default value] this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
       expect(tokens[10]).toEqual value: 'parameter.property', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -767,7 +767,7 @@ describe "JSDoc grammar", ->
 
       {tokens} = grammar.tokenizeLine('/** @param {object} [parameter.property = default value] this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
       expect(tokens[10]).toEqual value: 'parameter.property ', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -779,7 +779,7 @@ describe "JSDoc grammar", ->
 
       {tokens} = grammar.tokenizeLine('/** @param {object} [ parameter.property = default value ] this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
       expect(tokens[10]).toEqual value: ' parameter.property ', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -793,13 +793,13 @@ describe "JSDoc grammar", ->
     it "tokenises @param tags with wildcard types", ->
       {tokens} = grammar.tokenizeLine('/** @param {*} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '*', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '*', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
       {tokens} = grammar.tokenizeLine('/** @param {?} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '?', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '?', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -810,7 +810,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'myNamespace.MyClass', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'myNamespace.MyClass', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -821,7 +821,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'Foo~cb', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'Foo~cb', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -830,7 +830,7 @@ describe "JSDoc grammar", ->
     it "tokenises @param tags with multiple types", ->
       {tokens} = grammar.tokenizeLine('/** @param {function|string} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function|string', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function|string', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -840,26 +840,26 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'string', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[9]).toEqual value: '|number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'string', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[9]).toEqual value: '|number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[10]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[12]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[13]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
 
       {tokens} = grammar.tokenizeLine('/** @param {string|number[]} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'string|number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'string|number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[9]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[11]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {(number|function)} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '(number|function)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '(number|function)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -869,10 +869,10 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '(string', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[9]).toEqual value: '|number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '(string', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[9]).toEqual value: '|number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[10]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[12]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[13]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -880,10 +880,10 @@ describe "JSDoc grammar", ->
 
       {tokens} = grammar.tokenizeLine('/** @param {(string|number[])} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '(string|number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[9]).toEqual value: ')', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '(string|number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[9]).toEqual value: ')', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[10]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[12]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[13]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -893,7 +893,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '?number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '?number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
@@ -901,7 +901,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '!number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '!number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
@@ -909,7 +909,7 @@ describe "JSDoc grammar", ->
       {tokens} = grammar.tokenizeLine('/** @param {...number} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '...number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '...number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
@@ -918,7 +918,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '...*', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '...*', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'remainder', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[11]).toEqual value: '*/', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.definition.comment.end.js']
@@ -928,7 +928,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '...?', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '...?', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'remainder', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[11]).toEqual value: '*/', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.definition.comment.end.js']
@@ -936,16 +936,16 @@ describe "JSDoc grammar", ->
     it "tokenises @param tags using Google Closure Compiler syntax", ->
       {tokens} = grammar.tokenizeLine('/** @param {number=} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'number=', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'number=', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {number[]} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[9]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[11]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
@@ -954,10 +954,10 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'Foo', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[9]).toEqual value: '.bar', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'Foo', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[9]).toEqual value: '.bar', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[10]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[12]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[13]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -966,14 +966,14 @@ describe "JSDoc grammar", ->
       {tokens} = grammar.tokenizeLine('/** @param {Array<number>} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'Array<number>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'Array<number>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {Array.<number>} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'Array.<number>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'Array.<number>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -981,7 +981,7 @@ describe "JSDoc grammar", ->
       {tokens} = grammar.tokenizeLine('/** @param {Array<number>|Array<string>} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'Array<number>|Array<string>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'Array<number>|Array<string>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -989,21 +989,21 @@ describe "JSDoc grammar", ->
       {tokens} = grammar.tokenizeLine('/** @param {Array.<number>|Array.<string>} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'Array.<number>|Array.<string>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'Array.<number>|Array.<string>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {(Array<number>|Array<string>)} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '(Array<number>|Array<string>)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '(Array<number>|Array<string>)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {(Array.<number>|Array.<string>)} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '(Array.<number>|Array.<string>)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '(Array.<number>|Array.<string>)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -1011,7 +1011,7 @@ describe "JSDoc grammar", ->
       {tokens} = grammar.tokenizeLine('/** @param {Object<string, number>} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'Object<string, number>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'Object<string, number>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -1019,7 +1019,7 @@ describe "JSDoc grammar", ->
       {tokens} = grammar.tokenizeLine('/** @param {Object.<string, number>} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'Object.<string, number>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'Object.<string, number>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -1027,7 +1027,7 @@ describe "JSDoc grammar", ->
       {tokens} = grammar.tokenizeLine('/** @param {Object<string, number>|Array<number>} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'Object<string, number>|Array<number>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'Object<string, number>|Array<number>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -1035,7 +1035,7 @@ describe "JSDoc grammar", ->
       {tokens} = grammar.tokenizeLine('/** @param {Object.<string, number>|Array.<number>} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'Object.<string, number>|Array.<number>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'Object.<string, number>|Array.<number>', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
       expect(tokens[10]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -1043,105 +1043,105 @@ describe "JSDoc grammar", ->
       {tokens} = grammar.tokenizeLine('/** @param {(Array<number>|Object<string, number>)} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '(Array<number>|Object<string, number>)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '(Array<number>|Object<string, number>)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {(Array.<number>|Object.<string, number>)} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '(Array.<number>|Object.<string, number>)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '(Array.<number>|Object.<string, number>)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function()} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function()', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function()', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function ()} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function ()', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function ()', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function ( )} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function ( )', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function ( )', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function(string)} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function(string)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function(string, number)} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string, number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function(string, number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function(...string)} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(...string)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function(...string)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function(string, ...number)} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string, ...number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function(string, ...number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function(string, number, ...number)} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string, number, ...number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function(string, number, ...number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function(!string)} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(!string)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function(!string)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function(?string, !number)} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(?string, !number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function(?string, !number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function(string[], number=)} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[9]).toEqual value: ', number=)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function(string', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[9]).toEqual value: ', number=)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[10]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[12]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function():number} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function():number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function():number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function(string): number} variable this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string): number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function(string): number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @param {function(string) : number} variable this is the description */')
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string) : number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function(string) : number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
 
@@ -1151,7 +1151,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'return', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: '*/', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.definition.comment.end.js']
 
@@ -1160,7 +1160,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'returns', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: '*/', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.definition.comment.end.js']
 
@@ -1170,7 +1170,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'returns', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'this', scopes: ['source.js', 'comment.block.documentation.js']
       expect(tokens[10]).toEqual value: ' is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -1181,7 +1181,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'return', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'object', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: 'this', scopes: ['source.js', 'comment.block.documentation.js']
       expect(tokens[10]).toEqual value: ' is the description ', scopes: ['source.js', 'comment.block.documentation.js']
@@ -1190,14 +1190,14 @@ describe "JSDoc grammar", ->
       {tokens} = grammar.tokenizeLine('/** @returns {(Something)} */')
       expect(tokens[3]).toEqual value: 'returns', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '(Something)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '(Something)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
     it "tokenises @return tags with multiple types", ->
       {tokens} = grammar.tokenizeLine('/** @return {Some|Thing} Something to return */')
       expect(tokens[3]).toEqual value: 'return', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'Some|Thing', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'Some|Thing', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {(String[]|Number[])} Description */')
@@ -1205,13 +1205,13 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'return', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '(String', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[9]).toEqual value: '|Number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[10]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[11]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[12]).toEqual value: ')', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '(String', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[9]).toEqual value: '|Number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[10]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[11]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[12]).toEqual value: ')', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[13]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[15]).toEqual value: 'Description', scopes: ['source.js', 'comment.block.documentation.js']
       expect(tokens[17]).toEqual value: '*/', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.definition.comment.end.js']
@@ -1221,78 +1221,78 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'return', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function()', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function()', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function ()} this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function ()', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function ()', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function ( )} this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function ( )', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function ( )', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function(string)} this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function(string)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function(string, number)} this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string, number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function(string, number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function(...string)} this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(...string)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function(...string)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function(string, ...number)} this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string, ...number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function(string, ...number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function(string, number, ...number)} this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string, number, ...number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function(string, number, ...number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function(!string)} this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(!string)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function(!string)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function(?string, !number)} this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(?string, !number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function(?string, !number)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function(string[], number=)} this is the description */')
       expect(tokens[3]).toEqual value: 'return', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
-      expect(tokens[9]).toEqual value: ', number=)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function(string', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[7]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[8]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
+      expect(tokens[9]).toEqual value: ', number=)', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[10]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function():number} this is the description */')
       expect(tokens[3]).toEqual value: 'return', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function():number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function():number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function(string): number} this is the description */')
       expect(tokens[3]).toEqual value: 'return', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string): number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function(string): number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
       {tokens} = grammar.tokenizeLine('/** @return {function(string) : number} this is the description */')
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'function(string) : number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'function(string) : number', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
 
   describe "highlighted JavaScript examples", ->
@@ -1415,7 +1415,7 @@ describe "JSDoc grammar", ->
       expect(lines[3][1]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(lines[3][2]).toEqual value: 'return', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(lines[3][4]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(lines[3][5]).toEqual value: 'String', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(lines[3][5]).toEqual value: 'String', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(lines[3][6]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(lines[3][7]).toEqual value: '', scopes: ['source.js', 'comment.block.documentation.js']
       expect(lines[4][1]).toEqual value: '*/', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.definition.comment.end.js']
@@ -1428,7 +1428,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'String ', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'String ', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '*/', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.definition.comment.end.js']
       expect(tokens[8]).toEqual value: ' aa', scopes: ['source.js']
 
@@ -1437,7 +1437,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: '*', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: '*', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
       expect(tokens[10]).toEqual value: 'name', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
@@ -1463,7 +1463,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'string="Foo', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'string="Foo', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '*/', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.definition.comment.end.js']
       expect(tokens[8]).toEqual value: 'oo', scopes: ['source.js']
       expect(tokens[9]).toEqual value: '"', scopes: ['source.js', 'string.quoted.double.js', 'punctuation.definition.string.begin.js']
@@ -1507,7 +1507,7 @@ describe "JSDoc grammar", ->
       expect(tokens[2]).toEqual value: '@', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc', 'punctuation.definition.block.tag.jsdoc']
       expect(tokens[3]).toEqual value: 'param', scopes: ['source.js', 'comment.block.documentation.js', 'storage.type.class.jsdoc']
       expect(tokens[5]).toEqual value: '{', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.begin.jsdoc']
-      expect(tokens[6]).toEqual value: 'Something', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc']
+      expect(tokens[6]).toEqual value: 'Something', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc.meta.embedded']
       expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'comment.block.documentation.js', 'entity.name.type.instance.jsdoc', 'punctuation.definition.bracket.curly.end.jsdoc']
       expect(tokens[9]).toEqual value: '[', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.begin.bracket.square.jsdoc']
       expect(tokens[10]).toEqual value: 'value', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']


### PR DESCRIPTION
https://github.com/Microsoft/TypeScript-TmLanguage/issues/537

### Description of the Change

VS Code uses the meta.embedded scope to mark sections of strings or comments as actually being code instead of string or comment content. This change adds the meta embedded scope to the contents of jsdoc types


### Alternate Designs

Instead of modifying the existing `"contentName"`, it may be better to add a new scope for `meta.embedded.line.js`. I wasn't able to figure out how to do this. Let me know if you have any suggestions

### Benefits

Marker for what is code content with a jsdoc 

### Possible Drawbacks

Changes existing scopes

### Applicable Issues

https://github.com/Microsoft/TypeScript-TmLanguage/issues/537
