### PR TITLE
Allow more punctuation to precede regexes

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1130,7 +1130,7 @@
     'name': 'constant.language.js'
   }
   {
-    'begin': '(?<=[\\[=(?:+,!]|^|return|=>|&&|\\|\\|)\\s*(/)(?![/*+?])(?=.*/)'
+    'begin': '(?<=[\\[{=(?:+*,!~-]|^|return|=>|&&|\\|\\|)\\s*(/)(?![/*+?])(?=.*/)'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.string.begin.js'

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -216,6 +216,14 @@ describe "JavaScript grammar", ->
       expect(tokens[6]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.end.js']
       expect(tokens[7]).toEqual value: ']', scopes: ['source.js', 'meta.brace.square.js']
 
+    it "tokenizes regular expressions inside curly brackets", ->
+      {tokens} = grammar.tokenizeLine('{/test/}')
+      expect(tokens[0]).toEqual value: '{', scopes: ['source.js', 'meta.brace.curly.js']
+      expect(tokens[1]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.begin.js']
+      expect(tokens[2]).toEqual value: 'test', scopes: ['source.js', 'string.regexp.js']
+      expect(tokens[3]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.end.js']
+      expect(tokens[4]).toEqual value: '}', scopes: ['source.js', 'meta.brace.curly.js']
+
     it "tokenizes regular expressions inside arrow function expressions", ->
       {tokens} = grammar.tokenizeLine('getRegex = () => /^helloworld$/;')
       expect(tokens[9]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.begin.js']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Supports the use case of @iskitz.

### Alternate Designs

Figure out a better way to differentiate division from regex.

### Benefits

ionify and regexes in inline blocks will be tokenized correctly.

### Possible Drawbacks

I don't think there will be any - all the punctuation I added can't be used for division.

### Applicable Issues

https://github.com/atom/language-javascript/issues/530#issuecomment-341976488