### PR TITLE
Add Jest Snapshot File Format

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -15,6 +15,7 @@
   'pac'
   'pjs'
   'sjs'
+  'snap'
   'xsjs'
   'xsjslib'
 ]


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Adds the Jest Snapshot file extension to the list of Grammar extensions. For more information on the file format see the [Jest documentation](https://facebook.github.io/jest/docs/en/snapshot-testing.html).

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

It is very easy to create large snapshots. Because of this attempting to tokenize and color the large file could create performance issues for Atom.
