### PR TITLE
Add tree-sitter JavaScript grammar

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 version: "{build}"
 
+image: Visual Studio 2015
+
 platform: x64
 
 branches:

--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -137,7 +137,7 @@ scopes:
   '"async"': 'keyword.control'
   '"await"': 'keyword.control'
 
-  'jsx_attribute': 'entity.other.attribute-name'
+  'jsx_attribute > property_identifier': 'entity.other.attribute-name'
   'jsx_opening_element > identifier': 'entity.name.tag'
   'jsx_closing_element > identifier': 'entity.name.tag'
   'jsx_self_closing_element > identifier': 'entity.name.tag'

--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -1,28 +1,9 @@
 id: 'javascript'
-
 name: 'JavaScript'
-
 type: 'tree-sitter'
-
 parser: 'tree-sitter-javascript'
 
-folds:
-  delimiters: [
-    ['{', '}']
-    ['(', ')']
-    ['[', ']'],
-    ['jsx_opening_element', 'jsx_closing_element'],
-    ['<', '>', {afterChildCount: 1}]
-  ],
-
-  tokens: [
-    ['comment', 2, 2]
-    ['template_string', 1, 1]
-  ]
-
-fileTypes: [
-  'js'
-]
+fileTypes: ['js', 'jsx']
 
 firstLineMatch: '''(?x)
   # Hashbang
@@ -43,6 +24,20 @@ firstLineMatch: '''(?x)
   (?=\\s|:|$)
   )
 '''
+
+folds:
+  delimiters: [
+    ['{', '}']
+    ['(', ')']
+    ['[', ']']
+    ['jsx_opening_element', 'jsx_closing_element']
+    ['<', '>', {afterChildCount: 1}]
+  ]
+
+  tokens: [
+    ['comment', 2, 2]
+    ['template_string', 1, 1]
+  ]
 
 comments:
   start: '// '

--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -70,6 +70,9 @@ scopes:
   'false': 'constant.language.boolean.false'
   'comment': 'comment.block'
 
+  'template_substitution > "${"': 'punctuation.section.embedded'
+  'template_substitution > "}"': 'punctuation.section.embedded'
+
   '"("': 'punctuation.definition.parameters.begin.bracket.round'
   '")"': 'punctuation.definition.parameters.end.bracket.round'
   '"{"': 'punctuation.definition.function.body.begin.bracket.curly'

--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -1,0 +1,131 @@
+id: 'javascript'
+
+name: 'JavaScript'
+
+type: 'tree-sitter'
+
+parser: 'tree-sitter-javascript'
+
+folds:
+  delimiters: [
+    ['{', '}']
+    ['(', ')']
+    ['[', ']'],
+    ['jsx_opening_element', 'jsx_closing_element'],
+    ['<', '>', {afterChildCount: 1}]
+  ],
+
+  tokens: [
+    ['comment', 2, 2]
+    ['template_string', 1, 1]
+  ]
+
+fileTypes: [
+  'js'
+]
+
+firstLineMatch: '''(?x)
+  # Hashbang
+  ^\\#!.*(?:\\s|\\/|(?<=!)\\b)
+    (?:node|iojs|JavaScript)
+  (?:$|\\s)
+  |
+  # Modeline
+  (?i:
+    # Emacs
+    -\\*-(?:\\s*(?=[^:;\\s]+\\s*-\\*-)|(?:.*?[;\\s]|(?<=-\\*-))mode\\s*:\\s*)
+      (?:js|javascript)
+    (?=[\\s;]|(?<![-*])-\\*-).*?-\\*-
+  |
+  # Vim
+  (?:(?:\\s|^)vi(?:m[<=>]?\\d+|m)?|\\sex)(?=:(?=\\s*set?\\s[^\\n:]+:)|:(?!\\s*set?\\s))(?:(?:\\s|\\s*:\\s*)\\w*(?:\\s*=(?:[^\\n\\\\\\s]|\\\\.)*)?)*[\\s:](?:filetype|ft|syntax)\\s*=
+    javascript
+  (?=\\s|:|$)
+  )
+'''
+
+comments:
+  start: '// '
+
+scopes:
+  'program': 'source.js'
+
+  'class > identifier': 'entity.name.type.class'
+
+  'property_identifier': 'variable.other.object.property'
+
+  'function > identifier': 'entity.name.function'
+  'call_expression > identifier': 'entity.name.function'
+
+  'method_definition > property_identifier': 'entity.name.function'
+  'call_expression > member_expression > property_identifier': 'entity.name.function'
+
+  'new_expression > call_expression > identifier': 'meta.class.instance.constructor'
+
+  'import_specifier > identifier': 'variable.other.module'
+  'import_clause > identifier': 'variable.other.module'
+
+  'number': 'constant.numeric'
+  'string': 'string.quoted'
+  'regex': 'string.regexp'
+  'template_string': 'string.quoted.template'
+  'undefined': 'constant.language'
+  'null': 'constant.language.null'
+  'true': 'constant.language.boolean.true'
+  'false': 'constant.language.boolean.false'
+  'comment': 'comment.block'
+
+  '"("': 'punctuation.definition.parameters.begin.bracket.round'
+  '")"': 'punctuation.definition.parameters.end.bracket.round'
+  '"{"': 'punctuation.definition.function.body.begin.bracket.curly'
+  '"}"': 'punctuation.definition.function.body.end.bracket.curly'
+
+  '"var"': 'storage.type'
+  '"let"': 'storage.type'
+  '"class"': 'storage.type'
+  '"const"': 'storage.modifier'
+  '"static"': 'storage.modifier'
+  '"function"': 'storage.type'
+
+  '"+"': 'keyword.operator'
+  '"-"': 'keyword.operator'
+  '"*"': 'keyword.operator'
+  '"/"': 'keyword.operator'
+  '"in"': 'keyword.operator.in'
+  '"instanceof"': 'keyword.operator.instanceof'
+  '"of"': 'keyword.operator.of'
+  '"new"': 'keyword.operator.new'
+  '"typeof"': 'keyword.operator.typeof'
+
+  '"get"': 'keyword.operator.setter'
+  '"set"': 'keyword.operator.setter'
+
+  '"."': 'meta.delimiter'
+  '","': 'meta.delimiter'
+
+  '"if"': 'keyword.control'
+  '"do"': 'keyword.control'
+  '"else"': 'keyword.control'
+  '"while"': 'keyword.control'
+  '"for"': 'keyword.control'
+  '"return"': 'keyword.control'
+  '"break"': 'keyword.control'
+  '"continue"': 'keyword.control'
+  '"throw"': 'keyword.control'
+  '"try"': 'keyword.control'
+  '"catch"': 'keyword.control'
+  '"finally"': 'keyword.control'
+  '"switch"': 'keyword.control'
+  '"case"': 'keyword.control'
+  '"default"': 'keyword.control'
+  '"export"': 'keyword.control'
+  '"import"': 'keyword.control'
+  '"from"': 'keyword.control'
+  '"yield"': 'keyword.control'
+  '"async"': 'keyword.control'
+  '"await"': 'keyword.control'
+
+  'jsx_attribute': 'entity.other.attribute-name'
+  'jsx_opening_element > identifier': 'entity.name.tag'
+  'jsx_closing_element > identifier': 'entity.name.tag'
+  'jsx_self_closing_element > identifier': 'entity.name.tag'

--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -25,19 +25,33 @@ firstLineMatch: '''(?x)
   )
 '''
 
-folds:
-  delimiters: [
-    ['{', '}']
-    ['(', ')']
-    ['[', ']']
-    ['jsx_opening_element', 'jsx_closing_element']
-    ['<', '>', {afterChildCount: 1}]
-  ]
-
-  nodes: [
-    'comment',
-    'template_string',
-  ]
+folds: [
+  {
+    type: ['comment', 'template_string']
+  }
+  {
+    type: 'jsx_element'
+    start: {index: 0}
+    end: {index: -1}
+  }
+  {
+    type: 'jsx_self_closing_element'
+    start: {index: 1}
+    end: {index: -2}
+  }
+  {
+    start: {index: 0, type: '{'}
+    end: {index: -1, type: '}'}
+  }
+  {
+    start: {index: 0, type: '['}
+    end: {index: -1, type: ']'}
+  }
+  {
+    start: {index: 0, type: '('}
+    end: {index: -1, type: ')'}
+  }
+]
 
 comments:
   start: '// '

--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -27,10 +27,10 @@ firstLineMatch: '''(?x)
 
 folds: [
   {
-    type: ['comment', 'template_string']
+    type: 'comment'
   }
   {
-    type: 'jsx_element'
+    type: ['jsx_element', 'template_string'],
     start: {index: 0}
     end: {index: -1}
   }

--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -34,9 +34,9 @@ folds:
     ['<', '>', {afterChildCount: 1}]
   ]
 
-  tokens: [
-    ['comment', 2, 2]
-    ['template_string', 1, 1]
+  nodes: [
+    'comment',
+    'template_string',
   ]
 
 comments:

--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -2,6 +2,7 @@ id: 'javascript'
 name: 'JavaScript'
 type: 'tree-sitter'
 parser: 'tree-sitter-javascript'
+legacyScopeName: 'source.js'
 
 fileTypes: ['js', 'jsx']
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-javascript",
-  "version": "0.128.0-3",
+  "version": "0.128.0-4",
   "description": "JavaScript language support in Atom",
   "engines": {
     "atom": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-javascript",
-  "version": "0.127.7",
+  "version": "0.128.0-0",
   "description": "JavaScript language support in Atom",
   "engines": {
     "atom": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-javascript",
-  "version": "0.128.0-2",
+  "version": "0.128.0-3",
   "description": "JavaScript language support in Atom",
   "engines": {
     "atom": "*",

--- a/package.json
+++ b/package.json
@@ -17,5 +17,8 @@
   },
   "devDependencies": {
     "coffeelint": "^1.10.1"
+  },
+  "dependencies": {
+    "tree-sitter-javascript": "^0.4.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-javascript",
-  "version": "0.128.0-1",
+  "version": "0.128.0-2",
   "description": "JavaScript language support in Atom",
   "engines": {
     "atom": "*",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "coffeelint": "^1.10.1"
   },
   "dependencies": {
-    "tree-sitter-javascript": "^0.4.7"
+    "tree-sitter-javascript": "^0.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-javascript",
-  "version": "0.128.0-0",
+  "version": "0.128.0-1",
   "description": "JavaScript language support in Atom",
   "engines": {
     "atom": "*",


### PR DESCRIPTION
This adds an alternative JavaScript grammar that uses [tree-sitter-javascript](https://github.com/tree-sitter/tree-sitter-javascript) for parsing instead of [first-mate](https://github.com/atom/first-mate).
  