### PR TITLE
Fix multiline re-export of the default export

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -177,53 +177,6 @@
         'include': '#numbers'
       }
       {
-        # { member1 , member2 as alias2 , [...] } inside re-export
-        'begin': '{(?=.*\\bfrom\\b)'
-        'beginCaptures':
-          0:
-            'name': 'punctuation.definition.modules.begin.js'
-        'end': '}'
-        'endCaptures':
-          0:
-            'name': 'punctuation.definition.modules.end.js'
-        'patterns': [
-          {
-            # (default|name) as alias
-            'match': '''(?x)
-              (?: \\b(default)\\b | \\b([a-zA-Z_$][\\w$]*)\\b)
-              \\s*
-              (\\b as \\b)
-              \\s*
-              (?: \\b(default)\\b | (\\*) | \\b([a-zA-Z_$][\\w$]*)\\b)
-            '''
-            'captures':
-              '1':
-                'name': 'variable.language.default.js'
-              '2':
-                'name': 'variable.other.module.js'
-              '3':
-                'name': 'keyword.control.js'
-              '4':
-                'name': 'variable.language.default.js'
-              '5':
-                'name': 'invalid.illegal.js'
-              '6':
-                'name': 'variable.other.module-alias.js'
-          }
-          {
-            'match': ','
-            'name': 'meta.delimiter.object.comma.js'
-          }
-          {
-            'include': '#comments'
-          }
-          {
-            'match': '\\b([a-zA-Z_$][\\w$]*)\\b'
-            'name': 'variable.other.module.js'
-          }
-        ]
-      }
-      {
         # { member1 , member2 as alias2 , [...] }
         'begin': '(?![a-zA-Z_$0-9]){'
         'beginCaptures':
@@ -238,7 +191,7 @@
             # name as (default|alias)
             'captures':
               '1':
-                'name': 'invalid.illegal.js'
+                'name': 'variable.language.default.js'
               '2':
                 'name': 'variable.other.module.js'
               '3':

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -1099,6 +1099,29 @@ describe "JavaScript grammar", ->
       expect(tokens[10]).toEqual value: '}', scopes: ['source.js', 'meta.export.js', 'punctuation.definition.modules.end.js']
       expect(tokens[12]).toEqual value: 'from', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
 
+    it "tokenizes multiline re-export", ->
+      lines = grammar.tokenizeLines '''
+        export {
+          default as alias,
+          member1 as alias1,
+          member2,
+        } from "module-name";
+      '''
+      expect(lines[0][0]).toEqual value: 'export', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
+      expect(lines[0][2]).toEqual value: '{', scopes: ['source.js', 'meta.export.js', 'punctuation.definition.modules.begin.js']
+      expect(lines[1][1]).toEqual value: 'default', scopes: ['source.js', 'meta.export.js', 'variable.language.default.js']
+      expect(lines[1][3]).toEqual value: 'as', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
+      expect(lines[1][5]).toEqual value: 'alias', scopes: ['source.js', 'meta.export.js', 'variable.other.module-alias.js']
+      expect(lines[1][6]).toEqual value: ',', scopes: ['source.js', 'meta.export.js', 'meta.delimiter.object.comma.js']
+      expect(lines[2][1]).toEqual value: 'member1', scopes: ['source.js', 'meta.export.js', 'variable.other.module.js']
+      expect(lines[2][3]).toEqual value: 'as', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
+      expect(lines[2][5]).toEqual value: 'alias1', scopes: ['source.js', 'meta.export.js', 'variable.other.module-alias.js']
+      expect(lines[2][6]).toEqual value: ',', scopes: ['source.js', 'meta.export.js', 'meta.delimiter.object.comma.js']
+      expect(lines[3][1]).toEqual value: 'member2', scopes: ['source.js', 'meta.export.js', 'variable.other.module.js']
+      expect(lines[3][2]).toEqual value: ',', scopes: ['source.js', 'meta.export.js', 'meta.delimiter.object.comma.js']
+      expect(lines[4][0]).toEqual value: '}', scopes: ['source.js', 'meta.export.js', 'punctuation.definition.modules.end.js']
+      expect(lines[4][2]).toEqual value: 'from', scopes: ['source.js', 'meta.export.js', 'keyword.control.js']
+
   describe "ES6 yield", ->
     it "tokenizes yield", ->
       {tokens} = grammar.tokenizeLine('yield next')


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Fixes the highlighting when re-exporting a default export:

```js
export {
  default as alias,
} from 'module';
```

<img width="517" alt="screen shot 2018-01-31 at 12 57 07 pm" src="https://user-images.githubusercontent.com/6563105/35638889-5cb96414-0686-11e8-8dfc-01ee33895b93.png">

### Alternate Designs

Find an alternate regex.

### Benefits

The export will be properly tokenized.

### Possible Drawbacks

There could be a performance hit with the new regex.

### Applicable Issues

I actually did find one! #271