### PR TITLE
Add regular expression lookbehind highlighting.

### DIFF
--- a/grammars/regular expressions (javascript).cson
+++ b/grammars/regular expressions (javascript).cson
@@ -43,14 +43,18 @@
         'name': 'keyword.operator.or.regexp'
       }
       {
-        'begin': '(\\()((\\?=)|(\\?!))'
+        'begin': '(\\()(?:(\\?=)|(\\?!)|(\\?<=)|(\\?<!))'
         'beginCaptures':
           '1':
             'name': 'punctuation.definition.group.regexp'
-          '3':
+          '2':
             'name': 'meta.assertion.look-ahead.regexp'
-          '4':
+          '3':
             'name': 'meta.assertion.negative-look-ahead.regexp'
+          '4':
+            'name': 'meta.assertion.look-behind.regexp'
+          '5':
+            'name': 'meta.assertion.negative-look-behind.regexp'
         'end': '(\\))'
         'endCaptures':
           '1':

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -186,6 +186,32 @@ describe "JavaScript grammar", ->
       expect(tokens[1]).toEqual value: 'test', scopes: ['source.js', 'string.regexp.js']
       expect(tokens[2]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.end.js']
 
+      {tokens} = grammar.tokenizeLine('/(?<=foo)test(?=bar)/')
+      expect(tokens[0]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.begin.js']
+      expect(tokens[1]).toEqual value: '(', scopes: ['source.js', 'string.regexp.js', 'meta.group.assertion.regexp', 'punctuation.definition.group.regexp']
+      expect(tokens[2]).toEqual value: '?<=', scopes: ['source.js', 'string.regexp.js', 'meta.group.assertion.regexp', 'meta.assertion.look-behind.regexp']
+      expect(tokens[3]).toEqual value: 'foo', scopes: ['source.js', 'string.regexp.js', 'meta.group.assertion.regexp']
+      expect(tokens[4]).toEqual value: ')', scopes: ['source.js', 'string.regexp.js', 'meta.group.assertion.regexp', 'punctuation.definition.group.regexp']
+      expect(tokens[5]).toEqual value: 'test', scopes: ['source.js', 'string.regexp.js']
+      expect(tokens[6]).toEqual value: '(', scopes: ['source.js', 'string.regexp.js', 'meta.group.assertion.regexp', 'punctuation.definition.group.regexp']
+      expect(tokens[7]).toEqual value: '?=', scopes: ['source.js', 'string.regexp.js', 'meta.group.assertion.regexp', 'meta.assertion.look-ahead.regexp']
+      expect(tokens[8]).toEqual value: 'bar', scopes: ['source.js', 'string.regexp.js', 'meta.group.assertion.regexp']
+      expect(tokens[9]).toEqual value: ')', scopes: ['source.js', 'string.regexp.js', 'meta.group.assertion.regexp', 'punctuation.definition.group.regexp']
+      expect(tokens[10]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.end.js']
+
+      {tokens} = grammar.tokenizeLine('/(?<!\\$)test(?!\\.)/')
+      expect(tokens[0]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.begin.js']
+      expect(tokens[1]).toEqual value: '(', scopes: ['source.js', 'string.regexp.js', 'meta.group.assertion.regexp', 'punctuation.definition.group.regexp']
+      expect(tokens[2]).toEqual value: '?<!', scopes: ['source.js', 'string.regexp.js', 'meta.group.assertion.regexp', 'meta.assertion.negative-look-behind.regexp']
+      expect(tokens[3]).toEqual value: '\\$', scopes: ['source.js', 'string.regexp.js', 'meta.group.assertion.regexp', 'constant.character.escape.backslash.regexp']
+      expect(tokens[4]).toEqual value: ')', scopes: ['source.js', 'string.regexp.js', 'meta.group.assertion.regexp', 'punctuation.definition.group.regexp']
+      expect(tokens[5]).toEqual value: 'test', scopes: ['source.js', 'string.regexp.js']
+      expect(tokens[6]).toEqual value: '(', scopes: ['source.js', 'string.regexp.js', 'meta.group.assertion.regexp', 'punctuation.definition.group.regexp']
+      expect(tokens[7]).toEqual value: '?!', scopes: ['source.js', 'string.regexp.js', 'meta.group.assertion.regexp', 'meta.assertion.negative-look-ahead.regexp']
+      expect(tokens[8]).toEqual value: '\\.', scopes: ['source.js', 'string.regexp.js', 'meta.group.assertion.regexp', 'constant.character.escape.backslash.regexp']
+      expect(tokens[9]).toEqual value: ')', scopes: ['source.js', 'string.regexp.js', 'meta.group.assertion.regexp', 'punctuation.definition.group.regexp']
+      expect(tokens[10]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.end.js']
+
       {tokens} = grammar.tokenizeLine('/{"}/')
       expect(tokens[0]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.begin.js']
       expect(tokens[2]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.end.js']


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

-->

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

 1. Added support for regular expression lookbehind syntax highlighting, as the ECMAScript proposal has reached [stage 4](https://github.com/tc39/proposals/blob/master/finished-proposals.md), and is considered a 'finished proposal'.
2. Added unit tests for both lookahead and lookbehind syntax highlighting.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

The `meta.assertion.look-behind.regexp` scope was chosen so as to be consistent with the existing `meta.assertion.look-ahead.regexp` scope, though technically `meta.assertion.lookbehind.regexp` would have been better, as the term lookahead is used in the ECMAScript language specification with no dash.

### Benefits

<!-- What benefits will be realized by the code change? -->

Enables custom syntax highlighting of regular expression lookbehind assertions.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->

There weren't previously any unit tests testing regular expression lookahead/lookbehind highlighting, so there weren't any to test against.