### PR TITLE
Add regular expression s flag highlighting.

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1137,10 +1137,12 @@
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.string.begin.js'
-    'end': '(/)[gimuy]*'
+    'end': '(/)([gimsuy]*)'
     'endCaptures':
       '1':
         'name': 'punctuation.definition.string.end.js'
+      '2':
+        'name': 'meta.flag.regexp'
     'name': 'string.regexp.js'
     'patterns': [
       {

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -186,6 +186,22 @@ describe "JavaScript grammar", ->
       expect(tokens[1]).toEqual value: 'test', scopes: ['source.js', 'string.regexp.js']
       expect(tokens[2]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.end.js']
 
+      {tokens} = grammar.tokenizeLine('/random/g')
+      expect(tokens[0]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.begin.js']
+      expect(tokens[1]).toEqual value: 'random', scopes: ['source.js', 'string.regexp.js']
+      expect(tokens[2]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.end.js']
+      expect(tokens[3]).toEqual value: 'g', scopes: ['source.js', 'string.regexp.js', 'meta.flag.regexp']
+
+      {tokens} = grammar.tokenizeLine('/rock(et)?/is')
+      expect(tokens[0]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.begin.js']
+      expect(tokens[1]).toEqual value: 'rock', scopes: ['source.js', 'string.regexp.js']
+      expect(tokens[2]).toEqual value: '(', scopes: ['source.js', 'string.regexp.js', 'meta.group.regexp', 'punctuation.definition.group.regexp']
+      expect(tokens[3]).toEqual value: 'et', scopes: ['source.js', 'string.regexp.js', 'meta.group.regexp']
+      expect(tokens[4]).toEqual value: ')', scopes: ['source.js', 'string.regexp.js', 'meta.group.regexp', 'punctuation.definition.group.regexp']
+      expect(tokens[5]).toEqual value: '?', scopes: ['source.js', 'string.regexp.js', 'keyword.operator.quantifier.regexp']
+      expect(tokens[6]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.end.js']
+      expect(tokens[7]).toEqual value: 'is', scopes: ['source.js', 'string.regexp.js', 'meta.flag.regexp']
+
       {tokens} = grammar.tokenizeLine('/(?<=foo)test(?=bar)/')
       expect(tokens[0]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.begin.js']
       expect(tokens[1]).toEqual value: '(', scopes: ['source.js', 'string.regexp.js', 'meta.group.assertion.regexp', 'punctuation.definition.group.regexp']


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

-->

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

1. Adds support for regular expression `s`(`dotAll`) flag syntax highlighting, as [the ECMAScript proposal](https://github.com/tc39/proposal-regexp-dotall-flag) has reached stage 4, and is considered a ["finished proposal"](https://github.com/tc39/proposals/blob/master/finished-proposals.md).
2. Adds a third scope - `meta.flag.regexp` - to all regular expression flags (no change to existing scopes).
3. Adds unit tests for both single- and multi-flag regular expression syntax highlighting.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

The `meta.flag.regexp` scope was chosen instead of `meta.flag.regexp.js` to be consistent with other regular expression scopes like `meta.group.assertion.regexp`.

### Benefits

<!-- What benefits will be realized by the code change? -->

Adds support for the regular expression `s`(`dotAll`) flag, and enables custom syntax highlighting of all regular expression flags.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

There weren't previously any unit tests testing regular expression flag highlighting, so there weren't any to test against.

### Applicable Issues

<!-- Enter any applicable Issues here -->

None.