### PR TITLE
Update Promise highlighting.

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -865,6 +865,39 @@
     ]
   }
   {
+    # Promise
+    'begin': '(?<![\\w$])Promise(?![\\w$]|\\s*:)'
+    'beginCaptures':
+      '0':
+        'name': 'support.class.promise.js'
+    'end': '''(?x)
+      (?<=\\)) | (?=
+        (?! (\\s*//)|(\\s*/\\*)|(\\s*\\.\\s*(all|race|reject|resolve)\\s*\\() )\\s*\\S
+      )
+    '''
+    'patterns': [
+      {
+        'include': '#comments'
+      }
+      {
+        # Promise.all()
+        'begin': '\\s*(\\.)\\s*(\\w+)\\s*(?=\\()'
+        'beginCaptures':
+          '1':
+            'name': 'meta.delimiter.method.period.js'
+          '2':
+            'name': 'support.function.promise.js'
+        'end': '(?<=\\))'
+        'name': 'meta.method-call.js'
+        'patterns': [
+          {
+            'include': '#arguments'
+          }
+        ]
+      }
+    ]
+  }
+  {
     'include': '#strings'
   }
   {
@@ -987,7 +1020,7 @@
   {
     'match': '''(?x) (?<!\\$) \\b
       (Array|ArrayBuffer|Atomics|Boolean|DataView|Date|Error|EvalError|Float32Array|Float64Array|Function|Generator
-      |GeneratorFunction|Int16Array|Int32Array|Int8Array|InternalError|Intl|JSON|Map|Number|Object|Promise|Proxy
+      |GeneratorFunction|Int16Array|Int32Array|Int8Array|InternalError|Intl|JSON|Map|Number|Object|Proxy
       |RangeError|ReferenceError|Reflect|RegExp|Set|SharedArrayBuffer|SIMD|String|Symbol|SyntaxError|TypeError
       |Uint16Array|Uint32Array|Uint8Array|Uint8ClampedArray|URIError|WeakMap|WeakSet)
       \\b
@@ -1680,7 +1713,7 @@
               }
               {
                 'match': '''(?x)
-                  \\b(shift|showModelessDialog|showModalDialog|showHelp|scroll|scrollX|scrollByPages|
+                  \\b(catch|finally|then|shift|showModelessDialog|showModalDialog|showHelp|scroll|scrollX|scrollByPages|
                   scrollByLines|scrollY|scrollTo|stop|strike|sizeToContent|sidebar|signText|sort|
                   sup|sub|substr|substring|splice|split|send|set(Milliseconds|Seconds|Minutes|Hours|
                   Month|Year|FullYear|Date|UTC(Milliseconds|Seconds|Minutes|Hours|Month|FullYear|Date)|

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -1911,6 +1911,41 @@ describe "JavaScript grammar", ->
       expect(tokens[4]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
       expect(tokens[5]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
 
+  describe "promise", ->
+    it "tokenizes the promise object", ->
+      {tokens} = grammar.tokenizeLine('Promise;')
+      expect(tokens[0]).toEqual value: 'Promise', scopes: ['source.js', 'support.class.promise.js']
+      expect(tokens[1]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
+
+    it "tokenizes promise support functions", ->
+      {tokens} = grammar.tokenizeLine('Promise.race();')
+      expect(tokens[0]).toEqual value: 'Promise', scopes: ['source.js', 'support.class.promise.js']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+      expect(tokens[2]).toEqual value: 'race', scopes: ['source.js', 'meta.method-call.js', 'support.function.promise.js']
+      expect(tokens[3]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
+      expect(tokens[4]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
+      expect(tokens[5]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
+
+      lines = grammar.tokenizeLines '''
+        Promise
+        .resolve();
+      '''
+      expect(lines[0][0]).toEqual value: 'Promise', scopes: ['source.js', 'support.class.promise.js']
+      expect(lines[1][0]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+      expect(lines[1][1]).toEqual value: 'resolve', scopes: ['source.js', 'meta.method-call.js', 'support.function.promise.js']
+      expect(lines[1][2]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
+      expect(lines[1][3]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
+      expect(lines[1][4]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
+
+    it "tokenizes promise custom functions", ->
+      {tokens} = grammar.tokenizeLine('Promise.anExtraFunction();')
+      expect(tokens[0]).toEqual value: 'Promise', scopes: ['source.js', 'support.class.promise.js']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+      expect(tokens[2]).toEqual value: 'anExtraFunction', scopes: ['source.js', 'meta.method-call.js', 'entity.name.function.js']
+      expect(tokens[3]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
+      expect(tokens[4]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
+      expect(tokens[5]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
+
   describe "object literals", ->
     keywords = ['super', 'this', 'null', 'true', 'false', 'debugger', 'exports', '__filename']
 


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

-->

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

1. Adds support for `Promise` method call syntax highlighting.
2. Adds unit tests for both single- and multi-line `Promise` method call syntax highlighting.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

Other possibilities were considered in #358 for the `console` and `Math` objects - the solution that was settled on is replicated here for the `Promise` object.

### Benefits

<!-- What benefits will be realized by the code change? -->

Enables custom syntax highlighting of Promise method calls:

![Promise syntax highlighting.](https://user-images.githubusercontent.com/16239365/36236055-f498c020-11eb-11e8-96f3-6ae6cdac8296.png)

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

There weren't previously any unit tests testing `Promise` method call syntax highlighting, so there weren't any to test against.

### Applicable Issues

<!-- Enter any applicable Issues here -->

None.