### PR TITLE
Update console, Math and Promise highlighting.

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -788,14 +788,15 @@
       '0':
         'name': 'entity.name.type.object.console.js'
     'end': '''(?x)
-      (?<=\\)) | (?=
-        (?! (\\s*//)|(\\s*/\\*)|(\\s*(\\.)\\s*
-          (assert|clear|debug|error|info|log|profile|profileEnd|time|timeEnd|warn)
-          \\s*\\(
-        )) \\s*\\S
+      (?<=\\)) | (?=\\s*\\S)(?!
+        \\s*(//|/\\*|\\.\\s*(assert|clear|debug|error|info|log|profile|
+        profileEnd|time|timeEnd|warn)\\s*\\()
       )
     '''
     'patterns': [
+      {
+        'include': '#wrapped_line_comment'
+      }
       {
         'include': '#comments'
       }
@@ -823,17 +824,19 @@
       '0':
         'name': 'support.class.math.js'
     'end': '''(?x)
-      (?<=E|LN10|LN2|LOG10E|LOG2E|PI|SQRT1_2|SQRT2|\\)
-      ) | (?=
-        (?! (\\s*//)|(\\s*/\\*)|(\\s*\\.\\s* (
-          ((abs|acos|acosh|asin|asinh|atan|atan2|atanh|cbrt|ceil|clz32|cos|cosh|exp|
+      (?<=\\)) | (?<=[\\w$])(?<!^Math|[^\\w$]Math) | (?=\\s*\\S)(?!
+        \\s*(//|/\\*|\\.\\s*(
+          (abs|acos|acosh|asin|asinh|atan|atan2|atanh|cbrt|ceil|clz32|cos|cosh|exp|
           expm1|floor|fround|hypot|imul|log|log10|log1p|log2|max|min|pow|random|
           round|sign|sin|sinh|sqrt|tan|tanh|trunc)\\s*\\(
-          ) | (E|LN10|LN2|LOG10E|LOG2E|PI|SQRT1_2|SQRT2)(?!\\s*[\\w$(]))
-        )) \\s*\\S
+          | (E|LN10|LN2|LOG10E|LOG2E|PI|SQRT1_2|SQRT2)(?!\\s*[\\w$(])
+        ))
       )
     '''
     'patterns': [
+      {
+        'include': '#wrapped_line_comment'
+      }
       {
         'include': '#comments'
       }
@@ -871,11 +874,14 @@
       '0':
         'name': 'support.class.promise.js'
     'end': '''(?x)
-      (?<=\\)) | (?=
-        (?! (\\s*//)|(\\s*/\\*)|(\\s*\\.\\s*(all|race|reject|resolve)\\s*\\() )\\s*\\S
+      (?<=\\)) | (?=\\s*\\S)(?!
+        \\s*(//|/\\*|\\.\\s*(all|race|reject|resolve)\\s*\\()
       )
     '''
     'patterns': [
+      {
+        'include': '#wrapped_line_comment'
+      }
       {
         'include': '#comments'
       }
@@ -1971,6 +1977,18 @@
             'name': 'punctuation.definition.comment.js'
         'end': '$'
         'name': 'comment.line.double-slash.js'
+      }
+    ]
+  'wrapped_line_comment':
+    'patterns': [
+      {
+        'begin': '(//).*'
+        'beginCaptures':
+          '0':
+            'name': 'comment.line.double-slash.js'
+          '1':
+            'name': 'punctuation.definition.comment.js'
+        'end': '^'
       }
     ]
   'switch_statement':

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -1828,6 +1828,7 @@ describe "JavaScript grammar", ->
       expect(tokens[2]).toEqual value: 'log', scopes: ['source.js', 'meta.method-call.js', 'support.function.console.js']
       expect(tokens[3]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
       expect(tokens[4]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
+      expect(tokens[5]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
       expect(tokens[6]).not.toEqual value: 'log', scopes: ['source.js', 'meta.method-call.js', 'support.function.console.js']
 
       {tokens} = grammar.tokenizeLine('console/**/.log()')
@@ -1840,10 +1841,12 @@ describe "JavaScript grammar", ->
       expect(tokens[6]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
 
       lines = grammar.tokenizeLines '''
-        console
+        console//.log()
         .log();
       '''
       expect(lines[0][0]).toEqual value: 'console', scopes: ['source.js', 'entity.name.type.object.console.js']
+      expect(lines[0][1]).toEqual value: '//', scopes: ['source.js', 'comment.line.double-slash.js', 'punctuation.definition.comment.js']
+      expect(lines[0][2]).toEqual value: '.log()', scopes: ['source.js', 'comment.line.double-slash.js']
       expect(lines[1][0]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
       expect(lines[1][1]).toEqual value: 'log', scopes: ['source.js', 'meta.method-call.js', 'support.function.console.js']
       expect(lines[1][2]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
@@ -1876,6 +1879,12 @@ describe "JavaScript grammar", ->
       expect(tokens[0]).toEqual value: 'Math', scopes: ['source.js', 'support.class.math.js']
       expect(tokens[1]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
 
+      {tokens} = grammar.tokenizeLine('Math$')
+      expect(tokens[0]).not.toEqual value: 'Math', scopes: ['source.js', 'support.class.math.js']
+
+      {tokens} = grammar.tokenizeLine('$Math')
+      expect(tokens[1]).not.toEqual value: 'Math', scopes: ['source.js', 'support.class.math.js']
+
     it "tokenizes math support functions/properties", ->
       {tokens} = grammar.tokenizeLine('Math.random();')
       expect(tokens[0]).toEqual value: 'Math', scopes: ['source.js', 'support.class.math.js']
@@ -1886,21 +1895,39 @@ describe "JavaScript grammar", ->
       expect(tokens[5]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
 
       lines = grammar.tokenizeLines '''
-        Math
+        Math//.random()
         .random();
       '''
       expect(lines[0][0]).toEqual value: 'Math', scopes: ['source.js', 'support.class.math.js']
+      expect(lines[0][1]).toEqual value: '//', scopes: ['source.js', 'comment.line.double-slash.js', 'punctuation.definition.comment.js']
+      expect(lines[0][2]).toEqual value: '.random()', scopes: ['source.js', 'comment.line.double-slash.js']
       expect(lines[1][0]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
       expect(lines[1][1]).toEqual value: 'random', scopes: ['source.js', 'meta.method-call.js', 'support.function.math.js']
       expect(lines[1][2]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
       expect(lines[1][3]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
       expect(lines[1][4]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
 
+      {tokens} = grammar.tokenizeLine('Math.abs().random()')
+      expect(tokens[0]).toEqual value: 'Math', scopes: ['source.js', 'support.class.math.js']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+      expect(tokens[2]).toEqual value: 'abs', scopes: ['source.js', 'meta.method-call.js', 'support.function.math.js']
+      expect(tokens[3]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
+      expect(tokens[4]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
+      expect(tokens[5]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+      expect(tokens[6]).not.toEqual value: 'random', scopes: ['source.js', 'meta.method-call.js', 'support.function.math.js']
+
       {tokens} = grammar.tokenizeLine('Math.PI;')
       expect(tokens[0]).toEqual value: 'Math', scopes: ['source.js', 'support.class.math.js']
       expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.property.period.js']
       expect(tokens[2]).toEqual value: 'PI', scopes: ['source.js', 'support.constant.property.math.js']
       expect(tokens[3]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
+
+      {tokens} = grammar.tokenizeLine('Math.E.PI')
+      expect(tokens[0]).toEqual value: 'Math', scopes: ['source.js', 'support.class.math.js']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.property.period.js']
+      expect(tokens[2]).toEqual value: 'E', scopes: ['source.js', 'support.constant.property.math.js']
+      expect(tokens[3]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.property.period.js']
+      expect(tokens[4]).not.toEqual value: 'PI', scopes: ['source.js', 'support.constant.property.math.js']
 
     it "tokenizes math custom functions", ->
       {tokens} = grammar.tokenizeLine('Math.PI();')
@@ -1917,6 +1944,12 @@ describe "JavaScript grammar", ->
       expect(tokens[0]).toEqual value: 'Promise', scopes: ['source.js', 'support.class.promise.js']
       expect(tokens[1]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
 
+      {tokens} = grammar.tokenizeLine('Promise$')
+      expect(tokens[0]).not.toEqual value: 'Promise', scopes: ['source.js', 'support.class.promise.js']
+
+      {tokens} = grammar.tokenizeLine('$Promise')
+      expect(tokens[1]).not.toEqual value: 'Promise', scopes: ['source.js', 'support.class.promise.js']
+
     it "tokenizes promise support functions", ->
       {tokens} = grammar.tokenizeLine('Promise.race();')
       expect(tokens[0]).toEqual value: 'Promise', scopes: ['source.js', 'support.class.promise.js']
@@ -1927,15 +1960,26 @@ describe "JavaScript grammar", ->
       expect(tokens[5]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
 
       lines = grammar.tokenizeLines '''
-        Promise
+        Promise//.resolve()
         .resolve();
       '''
       expect(lines[0][0]).toEqual value: 'Promise', scopes: ['source.js', 'support.class.promise.js']
+      expect(lines[0][1]).toEqual value: '//', scopes: ['source.js', 'comment.line.double-slash.js', 'punctuation.definition.comment.js']
+      expect(lines[0][2]).toEqual value: '.resolve()', scopes: ['source.js', 'comment.line.double-slash.js']
       expect(lines[1][0]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
       expect(lines[1][1]).toEqual value: 'resolve', scopes: ['source.js', 'meta.method-call.js', 'support.function.promise.js']
       expect(lines[1][2]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
       expect(lines[1][3]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
       expect(lines[1][4]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
+
+      {tokens} = grammar.tokenizeLine('Promise.all().race()')
+      expect(tokens[0]).toEqual value: 'Promise', scopes: ['source.js', 'support.class.promise.js']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+      expect(tokens[2]).toEqual value: 'all', scopes: ['source.js', 'meta.method-call.js', 'support.function.promise.js']
+      expect(tokens[3]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
+      expect(tokens[4]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
+      expect(tokens[5]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+      expect(tokens[6]).not.toEqual value: 'race', scopes: ['source.js', 'meta.method-call.js', 'support.function.promise.js']
 
     it "tokenizes promise custom functions", ->
       {tokens} = grammar.tokenizeLine('Promise.anExtraFunction();')


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

-->

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

1. Updates `console`, `Math` and `Promise` object syntax highlighting, simplifying the relevant `end` regular expressions.
2. Adds more unit tests for `console`, `Math` and `Promise` object syntax highlighting.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

The regular expression `(?<!(^|[^\\w$])Math)` (variable-width lookbehind) is not supported by Atom's current regular expression engine, so `(?<!^Math|[^\\w$]Math)` is used instead.

### Benefits

<!-- What benefits will be realized by the code change? -->

1. Additional unit tests lower the chance of future regressions occurring.
2. Performance will be slightly improved when highlighting code with a large number of `console`, `Math` or `Promise` matches.
3. Enables syntax highlighting of method calls and properties when the previous line has a single-line comment ending with a `)`:
![Math syntax highlighting.](https://user-images.githubusercontent.com/16239365/36359178-3b466438-1510-11e8-9948-f7ee798aaa76.png)

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

There weren't previously enough unit tests testing `console`, `Math` and `Promise` syntax highlighting, so there weren't enough to test against.

### Applicable Issues

<!-- Enter any applicable Issues here -->

None.