### PR TITLE
Add regular expression named capture group highlighting.

### DIFF
--- a/grammars/regular expressions (javascript).cson
+++ b/grammars/regular expressions (javascript).cson
@@ -31,7 +31,7 @@
         'name': 'keyword.control.anchor.regexp'
       }
       {
-        'match': '\\\\[1-9]\\d*'
+        'match': '\\\\[1-9]\\d*|\\\\k<[a-zA-Z_$][\\w$]*>'
         'name': 'keyword.other.back-reference.regexp'
       }
       {
@@ -67,7 +67,7 @@
         ]
       }
       {
-        'begin': '\\((\\?:)?'
+        'begin': '\\(((\\?:)|(\\?<[a-zA-Z_$][\\w$]*>))?'
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.group.regexp'

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -202,6 +202,32 @@ describe "JavaScript grammar", ->
       expect(tokens[6]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.end.js']
       expect(tokens[7]).toEqual value: 'is', scopes: ['source.js', 'string.regexp.js', 'meta.flag.regexp']
 
+      {tokens} = grammar.tokenizeLine('/(foo)bar\\1/')
+      expect(tokens[0]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.begin.js']
+      expect(tokens[1]).toEqual value: '(', scopes: ['source.js', 'string.regexp.js', 'meta.group.regexp', 'punctuation.definition.group.regexp']
+      expect(tokens[2]).toEqual value: 'foo', scopes: ['source.js', 'string.regexp.js', 'meta.group.regexp']
+      expect(tokens[3]).toEqual value: ')', scopes: ['source.js', 'string.regexp.js', 'meta.group.regexp', 'punctuation.definition.group.regexp']
+      expect(tokens[4]).toEqual value: 'bar', scopes: ['source.js', 'string.regexp.js']
+      expect(tokens[5]).toEqual value: '\\1', scopes: ['source.js', 'string.regexp.js', 'keyword.other.back-reference.regexp']
+      expect(tokens[6]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.end.js']
+
+      {tokens} = grammar.tokenizeLine('/(?<bY_$>foo)bar\\k<bY_$>/')
+      expect(tokens[0]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.begin.js']
+      expect(tokens[1]).toEqual value: '(?<bY_$>', scopes: ['source.js', 'string.regexp.js', 'meta.group.regexp', 'punctuation.definition.group.regexp']
+      expect(tokens[2]).toEqual value: 'foo', scopes: ['source.js', 'string.regexp.js', 'meta.group.regexp']
+      expect(tokens[3]).toEqual value: ')', scopes: ['source.js', 'string.regexp.js', 'meta.group.regexp', 'punctuation.definition.group.regexp']
+      expect(tokens[4]).toEqual value: 'bar', scopes: ['source.js', 'string.regexp.js']
+      expect(tokens[5]).toEqual value: '\\k<bY_$>', scopes: ['source.js', 'string.regexp.js', 'keyword.other.back-reference.regexp']
+      expect(tokens[6]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.end.js']
+
+      {tokens} = grammar.tokenizeLine('/(?:foo)bar/')
+      expect(tokens[0]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.begin.js']
+      expect(tokens[1]).toEqual value: '(?:', scopes: ['source.js', 'string.regexp.js', 'meta.group.regexp', 'punctuation.definition.group.regexp']
+      expect(tokens[2]).toEqual value: 'foo', scopes: ['source.js', 'string.regexp.js', 'meta.group.regexp']
+      expect(tokens[3]).toEqual value: ')', scopes: ['source.js', 'string.regexp.js', 'meta.group.regexp', 'punctuation.definition.group.regexp']
+      expect(tokens[4]).toEqual value: 'bar', scopes: ['source.js', 'string.regexp.js']
+      expect(tokens[5]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.end.js']
+
       {tokens} = grammar.tokenizeLine('/(?<=foo)test(?=bar)/')
       expect(tokens[0]).toEqual value: '/', scopes: ['source.js', 'string.regexp.js', 'punctuation.definition.string.begin.js']
       expect(tokens[1]).toEqual value: '(', scopes: ['source.js', 'string.regexp.js', 'meta.group.assertion.regexp', 'punctuation.definition.group.regexp']


### PR DESCRIPTION
<!--

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

-->

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

1. Adds support for regular expression named capture group and named backreference syntax highlighting, as [the ECMAScript proposal](https://github.com/tc39/proposal-regexp-named-groups) has reached stage 4, and is considered a ['finished proposal'](https://github.com/tc39/proposals/blob/master/finished-proposals.md).
2. Adds unit tests for capture group, non-capture group, named capture group, named backreference and numbered backreference syntax highlighting.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

None.

### Benefits

<!-- What benefits will be realized by the code change? -->

Enables custom syntax highlighting of regular expression named capture groups and backreferences.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

There weren't previously any unit tests testing regular expression named capture group or named backreference syntax highlighting, so there weren't any to test against.

### Applicable Issues

<!-- Enter any applicable Issues here -->

None.