### PR TITLE
add delete keyword to tree-sitter grammar

### DIFF
--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -141,6 +141,7 @@ scopes:
   '"async"': 'keyword.control'
   '"await"': 'keyword.control'
   '"debugger"': 'keyword.control'
+  '"delete"': 'keyword.control'
 
   'jsx_attribute > property_identifier': 'entity.other.attribute-name'
   'jsx_opening_element > identifier': 'entity.name.tag'


### PR DESCRIPTION
### Description of the Change

Adds the `delete` keyword to the tree-sitter grammar.

### Alternate Designs

None

### Benefits

The `delete` operator is properly highlighted when using tree-sitter parser.

### Possible Drawbacks

None

### Applicable Issues

n/a


cc: @maxbrunsfeld 