### PR TITLE
add operator highlighting for ++ and --

### DIFF
--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -119,6 +119,8 @@ scopes:
   '"?"': 'keyword.operator.js'
   '"&&"': 'keyword.operator.js'
   '"||"': 'keyword.operator.js'
+  '"++"': 'keyword.operator.js'
+  '"--"': 'keyword.operator.js'
   
   '"in"': 'keyword.operator.in'
   '"instanceof"': 'keyword.operator.instanceof'


### PR DESCRIPTION
### Description of the Change

Adds tree-sitter syntax highlighting for `++` and `--` operators.

### Alternate Designs

Don't highlight these things.

### Benefits

These operators will be highlighted and it will match the way the text-mate grammar highlights them.

### Possible Drawbacks

Someone doesn't want these highlighted 😄 

### Applicable Issues

n/a


cc: @maxbrunsfeld 
