### PR TITLE
add spread operator syntax

### DIFF
--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -121,6 +121,7 @@ scopes:
   '"||"': 'keyword.operator.js'
   '"++"': 'keyword.operator.js'
   '"--"': 'keyword.operator.js'
+  '"..."': 'keyword.operator.js'
   
   '"in"': 'keyword.operator.in'
   '"instanceof"': 'keyword.operator.instanceof'


### PR DESCRIPTION
### Description of the Change

Adds syntax highlighting for the rest/spread operator (`...`).

### Alternate Designs

n/a

### Benefits

Spread operator is highlighted.

### Possible Drawbacks

You don't want the spread operator highlighted.
