### PR TITLE
add / to operators list

### DIFF
--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -106,6 +106,7 @@ scopes:
   '"+"': 'keyword.operator.js'
   '"-"': 'keyword.operator.js'
   '"*"': 'keyword.operator.js'
+  '"/"': 'keyword.operator.js'
   '"%"': 'keyword.operator.js'
   '"=="': 'keyword.operator.js'
   '"==="': 'keyword.operator.js'


### PR DESCRIPTION
### Description of the Change

Not sure how I missed this one earlier... whoops. Adds `/` to the list of operators in the grammar.

### Alternate Designs

Leave it out.

### Benefits

Division operator will be styled consistently with other mathematical operators.

### Possible Drawbacks

None.

### Applicable Issues

None.


cc: @maxbrunsfeld 