### PR TITLE
Make use of Tree-sitter grammar injection

### DIFF
--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -88,6 +88,7 @@ scopes:
 
   'template_substitution > "${"': 'punctuation.section.embedded'
   'template_substitution > "}"': 'punctuation.section.embedded'
+  'template_substitution': 'interpolation'
 
   '"("': 'punctuation.definition.parameters.begin.bracket.round'
   '")"': 'punctuation.definition.parameters.end.bracket.round'
@@ -123,7 +124,7 @@ scopes:
   '"++"': 'keyword.operator.js'
   '"--"': 'keyword.operator.js'
   '"..."': 'keyword.operator.js'
-  
+
   '"in"': 'keyword.operator.in'
   '"instanceof"': 'keyword.operator.instanceof'
   '"of"': 'keyword.operator.of'

--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -6,6 +6,8 @@ legacyScopeName: 'source.js'
 
 fileTypes: ['js', 'jsx']
 
+injectionRegExp: 'js|javascript'
+
 firstLineMatch: '''(?x)
   # Hashbang
   ^\\#!.*(?:\\s|\\/|(?<=!)\\b)

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,4 +1,6 @@
 exports.activate = function() {
+  if (!atom.grammars.addInjectionPoint) return
+
   atom.grammars.addInjectionPoint('javascript', {
     type: 'call_expression',
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,0 +1,39 @@
+exports.activate = function() {
+  atom.grammars.addInjectionPoint('javascript', {
+    type: 'call_expression',
+
+    language (callExpression) {
+      const {firstChild} = callExpression
+      if (firstChild.type === 'identifier') {
+        return firstChild.text
+      }
+    },
+
+    content (callExpression) {
+      const {lastChild} = callExpression
+      if (lastChild.type === 'template_string') {
+        return lastChild
+      }
+    }
+  })
+
+  atom.grammars.addInjectionPoint('javascript', {
+    type: 'assignment_expression',
+
+    language (callExpression) {
+      const {firstChild} = callExpression
+      if (firstChild.type === 'member_expression') {
+        if (firstChild.lastChild.text === 'innerHTML') {
+          return 'html'
+        }
+      }
+    },
+
+    content (callExpression) {
+      const {lastChild} = callExpression
+      if (lastChild.type === 'template_string') {
+        return lastChild
+      }
+    }
+  })
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-javascript",
-  "version": "0.128.9",
+  "version": "0.128.10-0",
   "description": "JavaScript language support in Atom",
   "engines": {
     "atom": "*",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "atom": "*",
     "node": "*"
   },
+  "main": "lib/main",
   "homepage": "http://atom.github.io/language-javascript",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR uses Atom's [new system](https://github.com/atom/atom/pull/17551) for handling injected languages with Tree-sitter. It allows syntax highlighting for:

* JavaScript inside of `script` tags in HTML files
* HTML inside of certain template strings in JavaScript files
* EJS templates