### PR TITLE
Add support for optional chaining within template literals

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1137,7 +1137,7 @@
     ]
   }
   {
-    'begin': '\\?'
+    'begin': '\\?(?!\\.)'
     'beginCaptures':
       '0':
         'name': 'keyword.operator.ternary.js'
@@ -1795,8 +1795,8 @@
         'name': 'constant.other.object.js'
       }
       {
-        # obj in obj.prop, obj.methodCall()
-        'match': '[a-zA-Z_$][\\w$]*(?=\\s*\\.\\s*[a-zA-Z_$]\\w*)'
+        # obj in obj.prop, obj.methodCall(), obj?.prop
+        'match': '[a-zA-Z_$][\\w$]*(?=\\s*\\??\\.\\s*[a-zA-Z_$]\\w*)'
         'name': 'variable.other.object.js'
       }
     ]

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -696,6 +696,17 @@ describe "JavaScript grammar", ->
       expect(tokens[13]).toEqual value: '}', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'punctuation.section.embedded.js']
       expect(tokens[14]).toEqual value: '`', scopes: ['source.js', 'string.quoted.template.js', 'punctuation.definition.string.end.js']
 
+    describe "ES6 string templates with optional chaining", ->
+      it "tokenizes them as strings", ->
+        {tokens} = grammar.tokenizeLine('`hey ${person?.name}`')
+        expect(tokens[0]).toEqual value: '`', scopes: ['source.js', 'string.quoted.template.js', 'punctuation.definition.string.begin.js']
+        expect(tokens[1]).toEqual value: 'hey ', scopes: ['source.js', 'string.quoted.template.js']
+        expect(tokens[2]).toEqual value: '${', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'punctuation.section.embedded.js']
+        expect(tokens[3]).toEqual value: 'person', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'variable.other.object.js']
+        expect(tokens[6]).toEqual value: 'name', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'support.variable.property.dom.js']
+        expect(tokens[7]).toEqual value: '}', scopes: ['source.js', 'string.quoted.template.js', 'source.js.embedded.source', 'punctuation.section.embedded.js']
+        expect(tokens[8]).toEqual value: '`', scopes: ['source.js', 'string.quoted.template.js', 'punctuation.definition.string.end.js']
+
   describe "HTML template strings", ->
     # TODO: Remove after Atom 1.21 is released
     [tagScope, entityScope] = []


### PR DESCRIPTION
### Description of the Change

- Change the pattern for matching objects to include support for optional changing, i.e. ```obj?.prop```
- Change the pattern for matching the ternary operator to fail if followed by a period

### Alternate Designs

None

### Benefits

Using conditional chaining will not break syntax highlighting as shown in #584

### Possible Drawbacks

I did not add any specific category for ```?```, but that could be handled in another PR

### Applicable Issues

#584 