### PR TITLE
Match the textmate styling a little more closely.

### DIFF
--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -68,9 +68,10 @@ scopes:
 
   'call_expression > identifier': [
     {match: '^require$', scopes: 'support.function'},
-    {match: '^[A-Z]', scopes: 'meta.class'},
     'entity.name.function'
   ]
+
+  'new_expression > call_expression > identifier': 'entity.name.type.instance.meta.constructor'
 
   'method_definition > property_identifier': 'entity.name.function'
   'call_expression > member_expression > property_identifier': 'entity.name.function'
@@ -98,7 +99,7 @@ scopes:
 
   'identifier': [
     {
-      match: '^(global|module|exports|__filename|__dirname)$',
+      match: '^(global|module|exports|__filename|__dirname|window|document)$',
       scopes: 'support.variable'
     },
     {


### PR DESCRIPTION
Specifically:
  - Don't mark CapitalizedWords as constructors in call expressions where they aren't invoked with `new`. In that case, use `entity.name.type.instance.meta.constructor`
  - Do highlight `window` and `document`. Stuff just looks dull otherwise.

Re: https://github.com/atom/atom/issues/17811