### PR TITLE
Colour generator functions too

### DIFF
--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -52,6 +52,7 @@ scopes:
   'property_identifier': 'variable.other.object.property'
 
   'function > identifier': 'entity.name.function'
+  'generator_function > identifier': 'entity.name.function'
 
   'call_expression > identifier': [
     {match: '^require$', scopes: 'support.function'},


### PR DESCRIPTION
### Description of the Change

Generator function names were not given scopes; now they are.

It seems [`language-typescript`](https://github.com/atom/language-typescript/blob/master/grammars/tree-sitter-typescript.cson) could also benefit from this.