### PR TITLE
Use `let` instead of `var` in for loops

### DIFF
--- a/snippets/language-javascript.cson
+++ b/snippets/language-javascript.cson
@@ -28,10 +28,10 @@
     'body': 'else if (${1:true}) {\n\t$2\n}'
   'for':
     'prefix' : 'for'
-    'body' : 'for (var ${2:i} = 0; ${2:i} < ${1:array}.length; ${2:i}++) {\n\t${1:array}[${2:i}]$3\n}'
+    'body' : 'for (let ${2:i} = 0; ${2:i} < ${1:array}.length; ${2:i}++) {\n\t${1:array}[${2:i}]$3\n}'
   'for in':
     'prefix': 'forin'
-    'body': 'for (var ${1:variable} in ${2:object}) {\n\t${3:if (${2:object}.hasOwnProperty(${1:variable})) {\n\t\t$4\n\t\\}}\n}'
+    'body': 'for (let ${1:variable} in ${2:object}) {\n\t${3:if (${2:object}.hasOwnProperty(${1:variable})) {\n\t\t$4\n\t\\}}\n}'
   'for of':
     'prefix': 'forof'
     'body': 'for (${1:variable} of ${2:iterable}) {\n\t$3\n}'


### PR DESCRIPTION
### Description of the Change

The for loop snippets are currently like this:
```
for (var i = 0; i < array.length; i++) {
	array[i]
}
```

I am proposing that we change them to this:
```
for (let i = 0; i < array.length; i++) {
	array[i]
}
```

*notice the difference in `var` vs `let`

### Benefits

When declared with `var`, for loop variables [are not local to the loop](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for#Syntax). They are put into the same scope as the for loop itself. When `let` is used, the variables *are* local to the loop.

If the same name is used in for loop variables in the same scope, this can lead to stange behavior/bugs.
```
function foo(arr1, arr2) {
    for (var i = 0; i > arr1.length; i++) { // `i` refers to the same variable, because it is in the function scope
        //do stuff...
    }

    for (var i = 0; i > arr2.length; i++) { // `i` refers to the same variable as above
        //do more stuff...
    }
}
```

### Possible Drawbacks

The only possible drawback I can think of is that `let` does not work prior to EMCAScript 6. This shouldn't be a problem, however, because it is [supported in all browsers](https://caniuse.com/#feat=let), and in Node.js.

