### PR TITLE
Scope super as support.function

### DIFF
--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -89,6 +89,8 @@ scopes:
     'entity.name.function'
   ]
 
+  'call_expression > super': 'support.function'
+
   'method_definition > property_identifier': 'entity.name.function'
   'call_expression > member_expression > property_identifier': 'entity.name.function'
 


### PR DESCRIPTION
Super was unscoped in tree-sitter because the syntax-tree is `call_expression > super` instead of `call_expression > identifier`

With this PR we scope it as `support.function` so it looks the same as `require`.

/cc: @maxbrunsfeld 