### PR TITLE
Self closing elements can also be meta.class

### DIFF
--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -73,6 +73,7 @@ scopes:
   '
     jsx_opening_element > identifier,
     jsx_closing_element > identifier,
+    jsx_self_closing_element > identifier,
     call_expression > identifier
   ': [
     {


### PR DESCRIPTION
### Description of the Change

Scope `jsx_self_closing_element` as `meta.class` if they match the regex. Same as `jsx_closing_element` and `jsx_opening_element`.

### Benefits

`jsx_self_closing_element` will be highlighted the same as the `jsx_closing_element` and `jsx_opening_element` elements. With the `meta.class` scope if they match the `^[A-Z]` regex.

### Possible Drawbacks

Someone wants self closing elements to be `entity.name.tag` even when they match the regex.

### Applicable Issues

/cc: @maxbrunsfeld Found myself writing some JSX and saw this so opening a PR to fix it.