### PR TITLE
Distinguish between commas and periods.

### DIFF
--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -196,8 +196,8 @@ scopes:
   '"get"': 'keyword.operator.setter'
   '"set"': 'keyword.operator.setter'
 
-  '"."': 'meta.delimiter'
-  '","': 'meta.delimiter'
+  '"."': 'meta.delimiter.period'
+  '","': 'meta.delimiter.comma'
 
   '"if"': 'keyword.control'
   '"do"': 'keyword.control'


### PR DESCRIPTION
### Description of the Change

The comma and period currently both have the same `meta.delimiter` scope, which makes it impossible to style them differently. This change modifies both so that they can be distinguished: `meta.delimiter.comma` and `meta.delimiter.period`.

### Alternate Designs

The `keyword.operator.accessor` scope would be more appropriate for the period as per the ECMAScript specification, but that might not work well with some themes.

### Benefits

It becomes possible to apply different styles to commas and periods.

### Possible Drawbacks

### Applicable Issues