### PR TITLE
Fold rules for switch_case

### DIFF
--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -41,6 +41,15 @@ folds: [
     start: {index: 0, type: '('}
     end: {index: -1, type: ')'}
   }
+  {
+    type: 'switch_case'
+    start: {index: 0}
+    end: {type: 'break_statement', index: -1}
+  }
+  {
+    type: 'switch_case'
+    start: {index: 0}
+  }
 ]
 
 comments:


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Folding `case` statements was not included in the tree-sitter grammar. With this PR we add a fold rule that folds up until the `break_statement` or folds the entire case if there isn't a `break_statement`.

All cases folded:
![image](https://user-images.githubusercontent.com/1058982/48223173-bff67600-e396-11e8-9fbc-d84854023237.png)

Some cases unfolded:
![image](https://user-images.githubusercontent.com/1058982/48223202-d0a6ec00-e396-11e8-8032-61e885c4ed77.png)


### Alternate Designs

Fold everything including the `break_statement`

### Benefits

* You can fold case
* You can see fall through structure very quickly when folded

### Possible Drawbacks

Someone wants the entire case to be folded including the break and we don't allow it!

### Applicable Issues

None