### PR TITLE
Differentiate line and block comments

### DIFF
--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -132,7 +132,13 @@ scopes:
   'null': 'constant.language.null'
   'true': 'constant.language.boolean.true'
   'false': 'constant.language.boolean.false'
-  'comment': 'comment.block'
+  'comment': [
+    {
+      match: "^//",
+      scopes: 'comment.line'
+    },
+    'comment.block'
+  ]
   'hash_bang_line': 'comment.block'
 
   '


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Tree-sitter currently treats all comments as `comment.block`. However, the distinction between block and line can be useful

For example, I'm trying to write a script that auto-comments newlines when created inside a line comment. I don't want it to do this inside a block comment, but it's difficult to tell which it is using the provided scopes. E.g., the desired behaviour is
```
// some |text

// some
// |text
```

but in an actual block comment, we would get
```
/*
some |text
*/

/*
some
// |text
*/
```

### Alternate Designs

The Tree-sitter grammar could differentiate comments.

### Benefits

More precise scoping

### Possible Drawbacks

Regular expressions can hurt performance. Hopefully, it can optimise this one, as it's only a constant two character check each time. It'd still feel better if there was a rule to match an exact start string (so just `//`).

### Applicable Issues

NA