### PR TITLE
Change scopes in comparison to language-babel

### DIFF
--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -67,6 +67,10 @@ scopes:
     'variable.other.object.property'
   ]
 
+  'member_expression > property_identifier': 'variable.other.object.property.unquoted'
+
+  'formal_parameters > identifier': 'formal-parameter.identifier'
+
   'shorthand_property_identifier': [
     {
       match: '^[\$A-Z_]{2,}$',
@@ -83,13 +87,14 @@ scopes:
     jsx_opening_element > identifier,
     jsx_closing_element > identifier,
     jsx_self_closing_element > identifier,
-    call_expression > identifier
   ': [
     {
       match: '^[A-Z]',
-      scopes: 'meta.class'
-    },
+      scopes: 'meta.class.component.jsx'
+    }
   ]
+
+  'call_expression > identifier': {match: '^[A-Z]', scopes: 'meta.class'}
 
   'function > identifier': 'entity.name.function'
   'generator_function > identifier': 'entity.name.function'
@@ -106,8 +111,12 @@ scopes:
 
   'identifier': [
     {
-      match: '^(global|module|exports|__filename|__dirname|window|document)$',
+      match: '^(global|module|exports|__filename|__dirname)$',
       scopes: 'support.variable'
+    },
+    {
+      match: '^(window|event|document|performance|screen|navigator|console)$'
+      scopes: 'support.variable.dom'
     },
     {
       exact: 'require',
@@ -199,7 +208,7 @@ scopes:
   '"|"': 'keyword.operator.js'
   '"++"': 'keyword.operator.js'
   '"--"': 'keyword.operator.js'
-  '"..."': 'keyword.operator.js'
+  '"..."': 'keyword.operator.spread.js'
 
   '"in"': 'keyword.operator.in'
   '"instanceof"': 'keyword.operator.instanceof'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

* Add a scope for formal parameter identifiers that is not styled in one-syntax
* Add `unquoted` to `member_expression > identifier`
* Add `component.jsx` to jsx components
* Add `spread` scope to the spread operator
* Scope some variables as `support.variable.dom`

### Benefits

Users of `language-babel` will see more familiar highlighting or can configure it to be more familiar and still get the benefits of tree-sitter parsers

### Possible Drawbacks

* `support.variable.dom` has the `variable` class so these will be highlighted as red in one-syntax. This is what TextMate scoped them as except for `console` which was `entity.name.other.console.js` or something.

I am open to change the scope for `support.variable.dom` and move back `window` and `document` to be `support.variable` if someone has a better scope name.

### Applicable Issues

Refs https://github.com/atom/language-javascript/issues/625

/cc: @maxbrunsfeld @atomiks