### PR TITLE
Add JSDoc injection w/ tree-sitter-jsdoc

### DIFF
--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -5,7 +5,7 @@ parser: 'tree-sitter-javascript'
 
 fileTypes: ['js', 'jsx']
 
-injectionRegex: 'js|javascript'
+injectionRegex: '^js$|^JS$|javascript|JavaScript'
 
 firstLineRegex: [
   # shebang line

--- a/grammars/tree-sitter-jsdoc.cson
+++ b/grammars/tree-sitter-jsdoc.cson
@@ -1,0 +1,11 @@
+name: 'JSDoc'
+scopeName: 'source.jsdoc'
+type: 'tree-sitter'
+parser: 'tree-sitter-jsdoc'
+
+injectionRegex: 'jsdoc'
+
+scopes:
+  '"@param", "@returns", "@alias", tag_name': 'keyword.control'
+  'param_tag > identifier, alias_tag > identifier': 'variable.other.jsdoc'
+  'type': 'support.type'

--- a/grammars/tree-sitter-jsdoc.cson
+++ b/grammars/tree-sitter-jsdoc.cson
@@ -3,9 +3,14 @@ scopeName: 'source.jsdoc'
 type: 'tree-sitter'
 parser: 'tree-sitter-jsdoc'
 
-injectionRegex: 'jsdoc'
+injectionRegex: '^jsdoc$'
 
 scopes:
-  '"@param", "@returns", "@alias", tag_name': 'keyword.control'
-  'param_tag > identifier, alias_tag > identifier': 'variable.other.jsdoc'
+  'tag_name': 'keyword.control'
+  'identifier': 'variable.other.jsdoc'
   'type': 'support.type'
+  'path_expression > identifier': 'string'
+  '"."': 'meta.delimiter.period'
+  '":"': 'meta.delimiter.colon'
+  '"/"': 'meta.delimiter.slash'
+  '"#", "~"': 'meta.delimiter'

--- a/lib/main.js
+++ b/lib/main.js
@@ -49,6 +49,18 @@ exports.activate = function () {
     language (regex) { return 'regex' },
     content (regex) { return regex }
   })
+
+  for (const scopeName of ['source.js', 'source.flow', 'source.ts']) {
+    atom.grammars.addInjectionPoint(scopeName, {
+      type: 'comment',
+      language (comment) {
+        if (comment.text.startsWith('/**')) return 'jsdoc'
+      },
+      content (comment) {
+        return comment
+      }
+    })
+  }
 }
 
 const STYLED_REGEX = /\bstyled\b/i

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "tree-sitter-javascript": "^0.13.8",
+    "tree-sitter-jsdoc": "^0.13.2",
     "tree-sitter-regex": "^0.13.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "tree-sitter-javascript": "^0.13.8",
-    "tree-sitter-jsdoc": "^0.13.3",
+    "tree-sitter-jsdoc": "^0.13.4",
     "tree-sitter-regex": "^0.13.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "tree-sitter-javascript": "^0.13.8",
-    "tree-sitter-jsdoc": "^0.13.2",
+    "tree-sitter-jsdoc": "^0.13.3",
     "tree-sitter-regex": "^0.13.1"
   }
 }


### PR DESCRIPTION
Fixes #600 

### Rationale

When we introduced Tree-sitter, we removed the feature of syntax-highlighting JSDoc comments in JavaScript. This PR adds back JSDoc highlighting using a new Tree-sitter parser: [tree-sitter-jsdoc](https://github.com/tree-sitter/tree-sitter-jsdoc).

![screen shot 2018-11-14 at 3 30 38 pm](https://user-images.githubusercontent.com/326587/48519607-56f18100-e822-11e8-98d6-e9f56f6dcec7.png)

### Possible Drawbacks

This adds many more injections in some JavaScript files, so it may affect performance. In the course of adding this, I already found and fixed two performance bottlenecks related to large numbers of language injections:

* https://github.com/atom/atom/pull/18435
* https://github.com/atom/atom/pull/18438

/cc @Ben3eeE 