### PR TITLE
Fix for...of autocomplete, variable declaration

### DIFF
--- a/snippets/language-javascript.cson
+++ b/snippets/language-javascript.cson
@@ -34,7 +34,7 @@
     'body': 'for (var ${1:variable} in ${2:object}) {\n\t${3:if (${2:object}.hasOwnProperty(${1:variable})) {\n\t\t$4\n\t\\}}\n}'
   'for of':
     'prefix': 'forof'
-    'body': 'for (${1:variable} of ${2:iterable}) {\n\t$3\n}'
+    'body': 'for (var ${1:variable} of ${2:iterable}) {\n\t$3\n}'
   'Function':
     'prefix': 'fun'
     'body': 'function ${1:functionName}($2) {\n\t$0\n}'


### PR DESCRIPTION


### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Following the for...of reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of

The variable declaration with "var" is missing and the autogenerated snippet produces a ReferenceError
if the variable used in the for is not declared previously in the code.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

The forof autocomplete snippet can be used safely.

### Possible Drawbacks

If the user wants to use an already declared variable, the declaration with "var" in the for has to be removed manually. 

### Applicable Issues

https://github.com/atom/language-javascript/issues/596
