### PR TITLE
Allow tagged template injections to accept function parameters

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -9,6 +9,8 @@ exports.activate = function () {
       switch (firstChild.type) {
         case 'identifier':
           return languageStringForTemplateTag(firstChild.text)
+        case 'call_expression':
+          return languageStringForTemplateTag(firstChild.children[0].text)
         case 'member_expression':
           if (firstChild.startPosition.row === firstChild.endPosition.row) {
             return languageStringForTemplateTag(firstChild.text)


### PR DESCRIPTION
### Description of the Change

This change fixes #634 which reports that the Tree-Sitter JavaScript grammar does not correctly highlight tagged template injections which have function parameters, such as those used in the [Styled Components](https://www.styled-components.com/) library.  The fix enables tagged template injections to be highlighted correctly when the template invocation includes function arguments.

**Before**

![styled_before](https://user-images.githubusercontent.com/79405/52385339-f2ffe280-2a35-11e9-9ce2-31d2a7c10db9.png)

**After**

![styled_fixed](https://user-images.githubusercontent.com/79405/52385345-f85d2d00-2a35-11e9-80b6-a73fb6372808.png)

### Alternate Designs

This is the simplest design that enables any tagged template literal to be called with arguments and then have a language injection to be applied.

### Benefits

CSS syntax inside of `styled` template literals with function arguments (`styled(Button)`) is now highlighted correctly.

### Possible Drawbacks
<!-- Enter any applicable Issues here -->
None

### Applicable Issues

Fixes #634