### PR TITLE
Remove invalid string highlighting from TextMate grammar

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1344,10 +1344,6 @@
           {
             'include': '#string_escapes'
           }
-          {
-            'match': "[^']*[^\\n\\r'\\\\]$"
-            'name': 'invalid.illegal.string.js'
-          }
         ]
       }
       {
@@ -1363,10 +1359,6 @@
         'patterns': [
           {
             'include': '#string_escapes'
-          }
-          {
-            'match': '[^"]*[^\\n\\r"\\\\]$'
-            'name': 'invalid.illegal.string.js'
           }
         ]
       }

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -51,7 +51,6 @@ describe "JavaScript grammar", ->
           line3
         """ + delim
         expect(lines[0][0]).toEqual value: delim, scopes: ['source.js', scope, 'punctuation.definition.string.begin.js']
-        expect(lines[0][1]).toEqual value: 'line1', scopes: ['source.js', scope, 'invalid.illegal.string.js']
         expect(lines[1][0]).toEqual value: 'line2\\', scopes: ['source.js', scope]
         expect(lines[2][0]).toEqual value: 'line3', scopes: ['source.js', scope]
         expect(lines[2][1]).toEqual value: delim, scopes: ['source.js', scope, 'punctuation.definition.string.end.js']

--- a/spec/jsdoc-spec.coffee
+++ b/spec/jsdoc-spec.coffee
@@ -1469,7 +1469,7 @@ describe "JSDoc grammar", ->
       expect(tokens[7]).toEqual value: '*/', scopes: ['source.js', 'comment.block.documentation.js', 'punctuation.definition.comment.end.js']
       expect(tokens[8]).toEqual value: 'oo', scopes: ['source.js']
       expect(tokens[9]).toEqual value: '"', scopes: ['source.js', 'string.quoted.double.js', 'punctuation.definition.string.begin.js']
-      expect(tokens[10]).toEqual value: '} bar', scopes: ['source.js', 'string.quoted.double.js', 'invalid.illegal.string.js']
+      expect(tokens[10]).toEqual value: '} bar', scopes: ['source.js', 'string.quoted.double.js']
 
     it "terminates any embedded JavaScript code", ->
       lines = grammar.tokenizeLines """


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

GitHub's [Linguist](https://github.com/github/linguist), which is used for syntax highlighting on GitHub.com, currently uses this grammar for highlighting Javascript and JSX. For quite some time now, users have experienced the problem where the presence of an apostrophe within JSX causes the syntax to be highlighted in red as an error:

![](https://user-images.githubusercontent.com/31365406/50696336-7e2a3900-1082-11e9-8475-694667df85b5.png) 

@Alhadis [proposed](https://github.com/github/linguist/issues/3044#issuecomment-459651756) the solution of removing the "rule which highlights unterminated strings as errors" which @50Wliu suggested would probably be fine as the TextMate grammars are no longer actively maintained:

> @Alhadis that's probably fine. We don't actively maintain the TextMate variants anymore, but I think this is something we'll merge a PR for.

@50Wliu opened https://github.com/atom/language-javascript/issues/641 to track this. I'm now implementing the changes suggested by @Alhadis in this PR.

This change _only_ affects the TextMate grammar as this is the grammar Linguist uses as tree-sitter grammars are not currently supported.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

Syntax highlighting on GitHub.com for Javascript with JSX that contains apostrophes will be rendered correctly.

### Possible Drawbacks

As this change only affects the TextMate grammar, there is a risk that the editor behaviour may vary slightly from the representation on GitHub.com for as long as we use the TextMate grammar.

### Applicable Issues

See https://github.com/github/linguist/issues/3044 for further details of the problem we're trying to resolve.

Fixes https://github.com/atom/language-javascript/issues/641

