### PR TITLE
Add more prototype methods to support.function scope

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1667,14 +1667,16 @@
               {
                 'match': '''(?x)
                   \\b(catch|finally|then|shift|showModelessDialog|showModalDialog|showHelp|scroll|scrollX|scrollByPages|
-                  scrollByLines|scrollY|scrollTo|stop|strike|sizeToContent|sidebar|signText|sort|
-                  sup|sub|substr|substring|splice|split|send|set(Milliseconds|Seconds|Minutes|Hours|
-                  Month|Year|FullYear|Date|UTC(Milliseconds|Seconds|Minutes|Hours|Month|FullYear|Date)|
-                  Time|Hotkeys|Cursor|ZOptions|Active|Resizable|RequestHeader)|search|slice|
+                  scrollByLines|scrollY|scrollTo|stop|strike|sizeToContent|sidebar|signText|send|sup|sub|hasOwnProperty|
+                  sort|copyWithin|every|substr|substring|slice|splice|split|map|reduce|reduceRight|filter|
+                  fill|flat|flatMap|unshift|every|some|includes|
+                  set(Milliseconds|Seconds|Minutes|Hours|Month|Year|FullYear|Date|
+                  UTC(Milliseconds|Seconds|Minutes|Hours|Month|FullYear|Date)|
+                  Time|Hotkeys|Cursor|ZOptions|Active|Resizable|RequestHeader)|search|
                   savePreferences|small|home|handleEvent|navigate|char|charCodeAt|charAt|concat|
-                  contextual|confirm|compile|clear|captureEvents|call|createStyleSheet|createPopup|
+                  contextual|confirm|compile|clear|captureEvents|call|bind|createStyleSheet|createPopup|
                   createEventObject|to(GMTString|UTCString|String|Source|UpperCase|LowerCase|LocaleString)|
-                  test|taint|taintEnabled|indexOf|italics|disableExternalCapture|dump|detachEvent|unshift|
+                  test|taint|taintEnabled|indexOf|italics|disableExternalCapture|dump|detachEvent|
                   untaint|unwatch|updateCommands|join|javaEnabled|pop|push|plugins.refresh|paddings|parse|stringify|
                   print|prompt|preference|enableExternalCapture|exec|execScript|valueOf|UTC|find|file|
                   fileModifiedDate|fileSize|fileCreatedDate|fileUpdatedDate|fixed|fontsize|fontcolor|


### PR DESCRIPTION
### Description of the Change

Adds more prorotype methods to `support.function`. For example with the Atom One Dark theme, these functions are a more cyan color compared to regular functions which are blue.

Includes 

- Array#{map,filter,reduce,reduceRight,flat,flatMap,every,some,includes,copyWithin}
- Function#bind
- Object#hasOwnProperty

### Alternate Designs

### Benefits

Less inconsistency in coloring when using methods

### Possible Drawbacks

None that I am aware of

### Applicable Issues

---

Ref: https://github.com/Microsoft/TypeScript-TmLanguage/issues/699