### PR TITLE
Allow folding switch_default

### DIFF
--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -42,12 +42,12 @@ folds: [
     end: {index: -1, type: ')'}
   }
   {
-    type: 'switch_case'
+    type: ['switch_case', 'switch_default']
     start: {index: 0}
     end: {type: 'break_statement', index: -1}
   }
   {
-    type: 'switch_case'
+    type: ['switch_case', 'switch_default']
     start: {index: 0}
   }
 ]


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

case statements in javascript are parsed as:
switch_statement > switch_body >switch_case

Default case statements in javascript are parsed as:
switch_statement >switch_body > switch_default

This PR adds `switch_default` to the folding rules so default can be folded with the same rule as case.

### Alternate Designs

N/A

### Benefits

Consistent folding rules for switch statements

### Possible Drawbacks

Someone likes unfoldable default and will open an issue that they can now fold it

### Applicable Issues

N/A

### Verification Process

```js
const fun = () => {
  switch (variable) {
    case DO_STUFF:
      do_stuff();
      break;
    case DO_OTHER_STUFF:
      do_other_stuff();
      test();
      break;
    default:
      do_stuff();
      test();
      break;
  }
};
```
* [x] Can not fold the default before this change
* [x] Can fold the default after this change
* [x] Run `editor:log-cursor-syntax-tree-scope` in the default and the switch to verify that they are parsed differently