### PR TITLE
Allow JS snippets to be used in Flow files

### DIFF
--- a/snippets/language-javascript.cson
+++ b/snippets/language-javascript.cson
@@ -1,4 +1,4 @@
-'.source.js':
+'.source.js, .source.flow':
   'Object Method':
     'prefix': 'kf'
     'body': '${1:methodName}: function (${2:attribute}) {\n\t$3\n}${4:,}'


### PR DESCRIPTION
Fixes https://github.com/atom/language-typescript/issues/29

Flow files are actually handled by `language-typescript`, but the JS snippets should all be applicable in that context. To address this, I add `.source.flow` to the selector for the JS snippets in this PR.