### PR TITLE
Colorize arrow function parameters without parens

### DIFF
--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -69,7 +69,7 @@ scopes:
 
   'member_expression > property_identifier': 'variable.other.object.property.unquoted'
 
-  'formal_parameters > identifier': 'formal-parameter.identifier'
+  'formal_parameters > identifier': 'variable.parameter.function'
 
   'shorthand_property_identifier': [
     {
@@ -95,6 +95,7 @@ scopes:
   ]
 
   'call_expression > identifier': {match: '^[A-Z]', scopes: 'meta.class'}
+  'arrow_function > identifier:nth-child(0)': 'variable.parameter.function'
 
   'function > identifier': 'entity.name.function'
   'generator_function > identifier': 'entity.name.function'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

This PR tokenizes single (paren-less) parameters for arrow functions. The first-mate source.js grammar already did this, while the current tree-sitter grammar does not. Consider the following screenshots:

**Current tree-sitter grammar:**  
<img width="321" alt="1-before" src="https://user-images.githubusercontent.com/872474/61260107-d462ed80-a731-11e9-9c61-851c60c62173.png">

**Tree-sitter grammar with this PR applied:**  
<img width="318" alt="2-after" src="https://user-images.githubusercontent.com/872474/61260117-dcbb2880-a731-11e9-8ae7-b3d78610bf26.png">

**Current first-mate grammar:**  
<img width="321" alt="3-firstmate" src="https://user-images.githubusercontent.com/872474/61260144-ee9ccb80-a731-11e9-8113-78243a6bac31.png">

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

A different selector could be used or the precedence of the grammar rule could be adjusted, if need be. Although this seems to work without any repercussions.

### Benefits

<!-- What benefits will be realized by the code change? -->

More consistent coloring for arrow function parameters, whether or not you use parens.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

I suppose if the selector chosen tokenizes more than it should, but I tried to keep it simple enough that it shouldn't be a concern.

### Applicable Issues

<!-- Enter any applicable Issues here -->

N/A
