### PR TITLE
Fix lost colorization of function declaration names

### DIFF
--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -97,6 +97,7 @@ scopes:
   'call_expression > identifier': {match: '^[A-Z]', scopes: 'meta.class'}
 
   'function > identifier': 'entity.name.function'
+  'function_declaration > identifier': 'entity.name.function'
   'generator_function > identifier': 'entity.name.function'
 
   'call_expression > identifier': [


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

A recent update to https://github.com/tree-sitter/tree-sitter-javascript restructured the way function declarations are constructed in the syntax tree. This change is not present in the latest stable Atom (v1.38.0 at the time of this writing), but is present when I forked language-javascript (v0.132.0 at the time of this writing).

In effect, when I cloned and linked `language-javascript`, the names for function declarations are no longer colorized.

**Current:**  
<img width="343" alt="1-before" src="https://user-images.githubusercontent.com/872474/61327632-3e30d500-a7ce-11e9-9d34-3b29ea1097ad.png">

This PR restores colorization for function declaration names, according to the new syntax tree structure.

**After this PR is merged:**  
<img width="346" alt="2-after" src="https://user-images.githubusercontent.com/872474/61327369-9a472980-a7cd-11e9-9252-871907036311.png">

**Syntax tree in Atom 1.38.0 (working):**  
<img width="601" alt="3-tree-old-working" src="https://user-images.githubusercontent.com/872474/61327424-bd71d900-a7cd-11e9-989a-8bc760c92830.png">

**Syntax tree in language-javascript 0.132.0 (what breaks things):**  
<img width="668" alt="4-tree-new-broken" src="https://user-images.githubusercontent.com/872474/61327455-d084a900-a7cd-11e9-9112-81bb548c3508.png">


### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

A different selector could theoretically be used, but `function_declaration > identifier` seemed most appropriate and consistent with what was already present in the grammar.

### Benefits

<!-- What benefits will be realized by the code change? -->

Colorization for function declaration names is restored to its former glory!

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None that I can see, as the change is small and limited in scope, and per my screenshot above, function expressions are not negatively impacted by this change.

### Applicable Issues

<!-- Enter any applicable Issues here -->

N/A
