### PR TITLE
Colorize rest parameters like other formal parameters

### DIFF
--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -70,7 +70,7 @@ scopes:
   'member_expression > property_identifier': 'variable.other.object.property.unquoted'
 
   'formal_parameters > identifier': 'variable.parameter.function'
-  'formal_parameters > rest_parameter > identifier': 'variable.parameter.function'
+  'formal_parameters > rest_parameter > identifier': 'variable.parameter.rest.function'
 
   'shorthand_property_identifier': [
     {

--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -69,7 +69,8 @@ scopes:
 
   'member_expression > property_identifier': 'variable.other.object.property.unquoted'
 
-  'formal_parameters > identifier': 'formal-parameter.identifier'
+  'formal_parameters > identifier': 'variable.parameter.function'
+  'formal_parameters > rest_parameter > identifier': 'variable.parameter.function'
 
   'shorthand_property_identifier': [
     {


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Currently, the tree-sitter grammar does not colorize rest parameters in functions. This is in contrast to the first-mate grammar, which _does_ colorize such parameters. This PR colorizes rest parameters as `formal-parameter.identifier`, like other function parameters.

**Before:**  
<img width="381" alt="1-before" src="https://user-images.githubusercontent.com/872474/61342446-0aba6e80-a7ff-11e9-86eb-a84af7acdb10.png">

**After (with these PR changes):**  
<img width="369" alt="2-after" src="https://user-images.githubusercontent.com/872474/61342459-127a1300-a7ff-11e9-8ab8-9e030b25707d.png">

**Current first-mate grammar:**  
<img width="366" alt="3-firstmate" src="https://user-images.githubusercontent.com/872474/61342483-2756a680-a7ff-11e9-8081-3d0262f9a192.png">

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

The selector was chosen because it is similar to the existing selector for formal parameters, so it should have no conflicts with other grammar rules.

### Benefits

<!-- What benefits will be realized by the code change? -->

Rest parameters are now treated just like other formal function parameters.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None that I can see, since the grammar rule's selector is limited in scope.

### Applicable Issues

<!-- Enter any applicable Issues here -->

N/A
