### PR TITLE
add node watchers

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -24,7 +24,7 @@
 'firstLineMatch': '''(?x)
   # Hashbang
   ^\\#!.*(?:\\s|\\/|(?<=!)\\b)
-    (?:node|iojs|JavaScript)
+    (?:node|iojs|JavaScript|node-dev|nodemon|forever|supervisor)
   (?:$|\\s)
   |
   # Modeline


### PR DESCRIPTION
### Description of the Change

Shebang detection of most common hot-reload wrappers: 
- node-dev
- nodemon
- supervisor
- forever


### Alternate Designs

I use https://github.com/julien-lang/atom-shebang-set-grammar, but finally decide to switch

### Benefits

You can name your executable files without extension and editor will understand grammar:
`fetch` and not `fetch.js`

### Possible Drawbacks

I'm not sure about popularity/usability of forever/supervisor

### Applicable Issues

Same as in "Benefits"
