### PR TITLE
Add a 'forEach'  snippet

### DIFF
--- a/snippets/language-javascript.cson
+++ b/snippets/language-javascript.cson
@@ -35,6 +35,9 @@
   'for of':
     'prefix': 'forof'
     'body': 'for (var ${1:variable} of ${2:iterable}) {\n\t$3\n}'
+  'forEach':
+    'prefix' : 'foreach'
+    'body' : 'forEach((${1:item}, ${2:i}) => {\n\t$3\n});\n'
   'Function':
     'prefix': 'fun'
     'body': 'function ${1:functionName}($2) {\n\t$0\n}'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

It is the simple addition of a single snippet. I did not find tests for these in previously merged commits of the same nature.

### Alternate Designs

I could instead use an anonymous function instead of arrow notation, but after a quick check on `caniuse.com` i decided against it.

### Benefits

sanity++

### Possible Drawbacks

Not all browsers may support arrow notation

### Applicable Issues
