### PR TITLE
add cjs file extension to grammars

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -2,6 +2,7 @@
 'fileTypes': [
   'js'
   '_js'
+  'cjs'
   'es'
   'es6'
   'gs'


### PR DESCRIPTION

### Description of the Change

I have to use .cjs extensions, but atom doesn't recognise them as js language, so I added the extension
