### PR TITLE
globalThis, self, frames

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1,3 +1,6 @@
+# Note: Because of the optional chaining operator (?.), "object.property" in the comments usually means ("object.property" or "object?.property")
+# Even though sometimes it doesn't seem like using the chaining operator would make any sense, it's still supported. example: Math?.PI
+# Negative lookbehinds for "." Shouldddd cover "?."
 'scopeName': 'source.js'
 'fileTypes': [
   'js'
@@ -44,7 +47,7 @@
 'name': 'JavaScript'
 'patterns': [
   {
-    # ES6 import
+    # ES6 import - Negative \\. *should* cover "?." right?
     'begin': '(?<!\\.)\\b(import)(?!\\s*[:(])\\b'
     'beginCaptures':
       '1':
@@ -284,8 +287,8 @@
     ]
   }
   {
-    # [.]foo = function...
-    'begin': '(?=(\\.)?[a-zA-Z_$][\\w$]*\\s*=\\s*(\\basync\\b\\s*)?\\bfunction\\b)'
+    # [.|?.]foo = function...
+    'begin': '(?=(\\.|\\?\\.)?[a-zA-Z_$][\\w$]*\\s*=\\s*(\\basync\\b\\s*)?\\bfunction\\b)'
     'end': '(?<=})'
     'patterns': [
       {
@@ -300,10 +303,10 @@
         'name': 'meta.function.js'
         'patterns': [
           {
-            'match': '(\\.)?([a-zA-Z_$][\\w$]*)\\s*(=)\\s*'
+            'match': '(\\.|\\?\\.)?([a-zA-Z_$][\\w$]*)\\s*(=)\\s*'
             'captures':
               '1':
-                'name': 'meta.delimiter.method.period.js'
+                'name': 'meta.delimiter.method.js'
               '2':
                 'name': 'entity.name.function.js'
               '3':
@@ -533,10 +536,10 @@
     ]
   }
   {
-    # [.]foo = ... => ...
+    # [.|?.]foo = ... => ...
     'begin': '''(?x)
       (?=
-        (\\.)?[a-zA-Z_$][\\w$]*
+        (\\.|\\?\\.)?[a-zA-Z_$][\\w$]*
         \\s*(=)\\s*
         ((\\(([^\\(\\)]*)?\\))|[\\w$]+)
         \\s*=>
@@ -546,8 +549,8 @@
       (?<=})|
       ((?!
         \\s*{|
-        \\G(\\.)?[a-zA-Z_$][\\w$]*\\s*(=)\\s*\\(|
-        \\G(\\.)?[a-zA-Z_$][\\w$]*\\s*(=)\\s*[\\w$]+|
+        \\G(\\.|\\?\\.)?[a-zA-Z_$][\\w$]*\\s*(=)\\s*\\(|
+        \\G(\\.|\\?\\.)?[a-zA-Z_$][\\w$]*\\s*(=)\\s*[\\w$]+|
         \\s*/\\*|\\s*//
       )(?=\\s*\\S))
     '''
@@ -564,10 +567,10 @@
         'name': 'meta.function.arrow.js'
         'patterns': [
           {
-            'match': '\\G(\\.)?([a-zA-Z_$][\\w$]*)\\s*(=)'
+            'match': '\\G(\\.|\\?\\.)?([a-zA-Z_$][\\w$]*)\\s*(=)'
             'captures':
               '1':
-                'name': 'meta.delimiter.method.period.js'
+                'name': 'meta.delimiter.method.js'
               '2':
                 'name': 'entity.name.function.js'
               '3':
@@ -729,8 +732,8 @@
         'name': 'entity.name.type.instance.js'
         'patterns': [
           {
-            'match': '\\.'
-            'name': 'meta.delimiter.property.period.js'
+            'match': '\\.|\\?\\.'
+            'name': 'meta.delimiter.property.js'
           }
         ]
   }
@@ -743,7 +746,7 @@
         'name': 'entity.name.type.object.console.js'
     'end': '''(?x)
       (?<=\\)) | (?=
-        (?! (\\s*//)|(\\s*/\\*)|(\\s*(\\.)\\s*
+        (?! (\\s*//)|(\\s*/\\*)|(\\s*(\\.|\\?\\.)\\s*
           (assert|clear|debug|error|info|log|profile|profileEnd|time|timeEnd|warn)
           \\s*\\(
         )) \\s*\\S
@@ -754,10 +757,10 @@
         'include': '#comments'
       }
       {
-        'begin': '\\s*(\\.)\\s*(\\w+)\\s*(?=\\()'
+        'begin': '\\s*(\\.|\\?\\.)\\s*(\\w+)\\s*(?=\\()'
         'beginCaptures':
           '1':
-            'name': 'meta.delimiter.method.period.js'
+            'name': 'meta.delimiter.method.js'
           '2':
             'name': 'support.function.console.js'
         'end': '(?<=\\))'
@@ -779,7 +782,7 @@
     'end': '''(?x)
       (?<=E|LN10|LN2|LOG10E|LOG2E|PI|SQRT1_2|SQRT2|\\)
       ) | (?=
-        (?! (\\s*//)|(\\s*/\\*)|(\\s*\\.\\s* (
+        (?! (\\s*//)|(\\s*/\\*)|(\\s*(\\.|\\?\\.)\\s* (
           ((abs|acos|acosh|asin|asinh|atan|atan2|atanh|cbrt|ceil|clz32|cos|cosh|exp|
           expm1|floor|fround|hypot|imul|log|log10|log1p|log2|max|min|pow|random|
           round|sign|sin|sinh|sqrt|tan|tanh|trunc)\\s*\\(
@@ -793,10 +796,10 @@
       }
       {
         # Math.random()
-        'begin': '\\s*(\\.)\\s*(\\w+)\\s*(?=\\()'
+        'begin': '\\s*(\\.|\\?\\.)\\s*(\\w+)\\s*(?=\\()'
         'beginCaptures':
           '1':
-            'name': 'meta.delimiter.method.period.js'
+            'name': 'meta.delimiter.method.js'
           '2':
             'name': 'support.function.math.js'
         'end': '(?<=\\))'
@@ -809,10 +812,10 @@
       }
       {
         # Math.PI
-        'match': '\\s*(\\.)\\s*(\\w+)\\b'
+        'match': '\\s*(\\.|\\?\\.)\\s*(\\w+)\\b'
         'captures':
           '1':
-            'name': 'meta.delimiter.property.period.js'
+            'name': 'meta.delimiter.property.js'
           '2':
             'name': 'support.constant.property.math.js'
       }
@@ -826,7 +829,7 @@
         'name': 'support.class.promise.js'
     'end': '''(?x)
       (?<=\\)) | (?=
-        (?! (\\s*//)|(\\s*/\\*)|(\\s*\\.\\s*(all|race|reject|resolve)\\s*\\() )\\s*\\S
+        (?! (\\s*//)|(\\s*/\\*)|(\\s*(\\.|\\?\\.)\\s*(all|race|reject|resolve)\\s*\\() )\\s*\\S
       )
     '''
     'patterns': [
@@ -835,10 +838,10 @@
       }
       {
         # Promise.all()
-        'begin': '\\s*(\\.)\\s*(\\w+)\\s*(?=\\()'
+        'begin': '\\s*(\\.|\\?\\.)\\s*(\\w+)\\s*(?=\\()'
         'beginCaptures':
           '1':
-            'name': 'meta.delimiter.method.period.js'
+            'name': 'meta.delimiter.method.js'
           '2':
             'name': 'support.function.promise.js'
         'end': '(?<=\\))'
@@ -941,6 +944,7 @@
     'name': 'meta.control.yield.js'
   }
   {
+    # Isn't about "." but rather "...", don't need to check "?."
     'match': '(?:(?<=\\.{3})|(?<!\\.))\\b(await)(?!\\s*:)\\b'
     'name': 'keyword.control.js'
   }
@@ -982,14 +986,14 @@
     'name': 'support.class.js'
   }
   {
-    'match': '''(?x) (\\.) \\s* (?:
+    'match': '''(?x) (\\.|\\?\\.) \\s* (?:
         (constructor|length|prototype) |
         (EPSILON|MAX_SAFE_INTEGER|MAX_VALUE|MIN_SAFE_INTEGER|MIN_VALUE|NEGATIVE_INFINITY|POSITIVE_INFINITY)
       )\\b
     '''
     'captures':
       '1':
-        'name': 'meta.delimiter.property.period.js'
+        'name': 'meta.delimiter.property.js'
       '2':
         'name': 'support.variable.property.js'
       '3':
@@ -1067,7 +1071,7 @@
         'name': 'support.class.dom.js'
   }
   {
-    'match': '''(?x) (\\.) \\s*
+    'match': '''(?x) (\\.|\\?\\.) \\s*
       (?:
         (ATTRIBUTE_NODE|CDATA_SECTION_NODE|COMMENT_NODE|DOCUMENT_FRAGMENT_NODE|DOCUMENT_NODE|DOCUMENT_TYPE_NODE
         |DOMSTRING_SIZE_ERR|ELEMENT_NODE|ENTITY_NODE|ENTITY_REFERENCE_NODE|HIERARCHY_REQUEST_ERR|INDEX_SIZE_ERR
@@ -1105,7 +1109,7 @@
     '''
     'captures':
       '1':
-        'name': 'meta.delimiter.property.period.js'
+        'name': 'meta.delimiter.property.js'
       '2':
         'name': 'support.constant.dom.js'
       '3':
@@ -1189,9 +1193,10 @@
     'match': ','
     'name': 'meta.delimiter.object.comma.js'
   }
-  {
-    'match': '\\.'
-    'name': 'meta.delimiter.method.period.js'
+  { 
+    # Optional chaining operator
+    'match': '\\.|\\?\\.'
+    'name': 'meta.delimiter.method.js'
   }
   {
     # Allows the special return snippet to fire.
@@ -1422,6 +1427,7 @@
         ]
       }
       {
+        # Don't think this could have optional chaining
         'begin': '(Relay\\.QL|gql)\\s*(`)'
         'beginCaptures':
           '1':
@@ -1637,11 +1643,11 @@
   'method_calls':
     'patterns': [
       {
-        # .methodCall(arg1, "arg2", [...])
-        'begin': '(\\.)\\s*([\\w$]+)\\s*(?=\\()'
+        # [?].methodCall(arg1, "arg2", [...])
+        'begin': '(\\.|\\?\\.)\\s*([\\w$]+)\\s*(?=\\()'
         'beginCaptures':
           '1':
-            'name': 'meta.delimiter.method.period.js'
+            'name': 'meta.delimiter.method.js'
           '2':
             'patterns': [
               {
@@ -1784,59 +1790,60 @@
     'patterns': [
       {
         # OBJ in OBJ.prop, OBJ.methodCall()
-        'match': '[A-Z][A-Z0-9_$]*(?=\\s*\\.\\s*[a-zA-Z_$]\\w*)'
+        'match': '[A-Z][A-Z0-9_$]*(?=\\s*(\\.|\\?\\.)\\s*[a-zA-Z_$]\\w*)'
         'name': 'constant.other.object.js'
       }
       {
         # obj in obj.prop, obj.methodCall()
-        'match': '[a-zA-Z_$][\\w$]*(?=\\s*\\.\\s*[a-zA-Z_$]\\w*)'
+        'match': '[a-zA-Z_$][\\w$]*(?=\\s*(\\.|\\?\\.)\\s*[a-zA-Z_$]\\w*)'
         'name': 'variable.other.object.js'
       }
     ]
   'properties':
     'patterns': [
+      # object.prop means (object.prop OR object?.prop) in this square bracket
       {
         # PROP1 in obj.PROP1.prop2, func().PROP1.prop2
-        'match': '(\\.)\\s*([A-Z][A-Z0-9_$]*\\b\\$*)(?=\\s*\\.\\s*[a-zA-Z_$]\\w*)'
+        'match': '(\\.|\\?\\.)\\s*([A-Z][A-Z0-9_$]*\\b\\$*)(?=\\s*(\\.|\\?\\.)\\s*[a-zA-Z_$]\\w*)'
         'captures':
           '1':
-            'name': 'meta.delimiter.property.period.js'
+            'name': 'meta.delimiter.property.js'
           '2':
             'name': 'constant.other.object.property.js'
       }
       {
         # prop1 in obj.prop1.prop2, func().prop1.prop2
-        'match': '(\\.)\\s*(\\$*[a-zA-Z_$][\\w$]*)(?=\\s*\\.\\s*[a-zA-Z_$]\\w*)'
+        'match': '(\\.|\\?\\.)\\s*(\\$*[a-zA-Z_$][\\w$]*)(?=\\s*(\\.|\\?\\.)\\s*[a-zA-Z_$]\\w*)'
         'captures':
           '1':
-            'name': 'meta.delimiter.property.period.js'
+            'name': 'meta.delimiter.property.js'
           '2':
             'name': 'variable.other.object.property.js'
       }
       {
         # PROP in obj.PROP, func().PROP
-        'match': '(\\.)\\s*([A-Z][A-Z0-9_$]*\\b\\$*)'
+        'match': '(\\.|\\?\\.)\\s*([A-Z][A-Z0-9_$]*\\b\\$*)'
         'captures':
           '1':
-            'name': 'meta.delimiter.property.period.js'
+            'name': 'meta.delimiter.property.js'
           '2':
             'name': 'constant.other.property.js'
       }
       {
         # prop in obj.prop, func().prop
-        'match': '(\\.)\\s*(\\$*[a-zA-Z_$][\\w$]*)'
+        'match': '(\\.|\\?\\.)\\s*(\\$*[a-zA-Z_$][\\w$]*)'
         'captures':
           '1':
-            'name': 'meta.delimiter.property.period.js'
+            'name': 'meta.delimiter.property.js'
           '2':
             'name': 'variable.other.property.js'
       }
       {
         # 123illegal in obj.123illegal, func().123illegal
-        'match': '(\\.)\\s*([0-9][\\w$]*)'
+        'match': '(\\.|\\?\\.)\\s*([0-9][\\w$]*)'
         'captures':
           '1':
-            'name': 'meta.delimiter.property.period.js'
+            'name': 'meta.delimiter.property.js'
           '2':
             'name': 'invalid.illegal.identifier.js'
       }

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -47,7 +47,7 @@
 'name': 'JavaScript'
 'patterns': [
   {
-    # ES6 import - Negative \\. *should* cover "?." right?
+    # ES6 import
     'begin': '(?<!\\.)\\b(import)(?!\\s*[:(])\\b'
     'beginCaptures':
       '1':

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1310,7 +1310,8 @@
         'name': 'keyword.operator.comparison.js'
       }
       {
-        'match': '&&|!!|!|\\|\\|'
+        # One of: && !! ! || ??
+        'match': '&&|!!|!|\\|\\||\\?\\?'
         'name': 'keyword.operator.logical.js'
       }
       {

--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -118,7 +118,7 @@ scopes:
       scopes: 'support.variable'
     },
     {
-      match: '^(window|self|event|document|performance|screen|navigator|console)$'
+      match: '^(window|self|frames|event|document|performance|screen|navigator|console)$'
       scopes: 'support.variable.dom'
     },
     {

--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -206,6 +206,7 @@ scopes:
   '"<"': 'keyword.operator.js'
   '":"': 'keyword.operator.js'
   '"?"': 'keyword.operator.js'
+  '"??"': 'keyword.operator.js'
   '"&&"': 'keyword.operator.js'
   '"||"': 'keyword.operator.js'
   '"&"': 'keyword.operator.js'
@@ -228,6 +229,7 @@ scopes:
   '"get"': 'keyword.operator.setter'
   '"set"': 'keyword.operator.setter'
 
+  '"?."': 'meta.delimiter.optional'
   '"."': 'meta.delimiter.period'
   '","': 'meta.delimiter.comma'
 

--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -114,11 +114,11 @@ scopes:
 
   'identifier': [
     {
-      match: '^(global|module|exports|__filename|__dirname)$',
+      match: '^(globalThis|global|module|exports|__filename|__dirname)$',
       scopes: 'support.variable'
     },
     {
-      match: '^(window|event|document|performance|screen|navigator|console)$'
+      match: '^(window|self|event|document|performance|screen|navigator|console)$'
       scopes: 'support.variable.dom'
     },
     {

--- a/spec/javascript-spec.coffee
+++ b/spec/javascript-spec.coffee
@@ -172,9 +172,9 @@ describe "JavaScript grammar", ->
       expect(tokens[4]).toEqual value: 'new', scopes: ['source.js', 'meta.class.instance.constructor.js', 'keyword.operator.new.js']
       expect(tokens[5]).toEqual value: ' ', scopes: ['source.js', 'meta.class.instance.constructor.js']
       expect(tokens[6]).toEqual value: 'obj', scopes: ['source.js', 'meta.class.instance.constructor.js', 'entity.name.type.instance.js']
-      expect(tokens[7]).toEqual value: '.', scopes: ['source.js', 'meta.class.instance.constructor.js', 'entity.name.type.instance.js', 'meta.delimiter.property.period.js']
+      expect(tokens[7]).toEqual value: '.', scopes: ['source.js', 'meta.class.instance.constructor.js', 'entity.name.type.instance.js', 'meta.delimiter.property.js']
       expect(tokens[8]).toEqual value: 'ct', scopes: ['source.js', 'meta.class.instance.constructor.js', 'entity.name.type.instance.js']
-      expect(tokens[9]).toEqual value: '.', scopes: ['source.js', 'meta.class.instance.constructor.js', 'entity.name.type.instance.js', 'meta.delimiter.property.period.js']
+      expect(tokens[9]).toEqual value: '.', scopes: ['source.js', 'meta.class.instance.constructor.js', 'entity.name.type.instance.js', 'meta.delimiter.property.js']
       expect(tokens[10]).toEqual value: 'Cla$s', scopes: ['source.js', 'meta.class.instance.constructor.js', 'entity.name.type.instance.js']
       expect(tokens[11]).toEqual value: '(', scopes: ['source.js', 'meta.brace.round.js']
       expect(tokens[12]).toEqual value: ')', scopes: ['source.js', 'meta.brace.round.js']
@@ -681,7 +681,7 @@ describe "JavaScript grammar", ->
       expect(tokens[0]).toEqual value: 'awesome ', scopes: ['source.js']
       expect(tokens[1]).toEqual value: '=', scopes: ['source.js', 'keyword.operator.assignment.js']
       expect(tokens[3]).toEqual value: 'cool', scopes: ['source.js', 'variable.other.object.js']
-      expect(tokens[4]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.property.period.js']
+      expect(tokens[4]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.property.js']
       expect(tokens[5]).toEqual value: 'EPSILON', scopes: ['source.js', 'support.constant.js']
       expect(tokens[6]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
 
@@ -751,7 +751,7 @@ describe "JavaScript grammar", ->
     it "tokenizes innerHTML attribute declarations with string template tags", ->
       {tokens} = grammar.tokenizeLine('text.innerHTML = `hey <b>${name}</b>`')
       expect(tokens[0]).toEqual value: 'text', scopes: ['source.js', 'variable.other.object.js']
-      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.property.period.js']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.property.js']
       expect(tokens[2]).toEqual value: 'innerHTML', scopes: ['source.js', 'variable.other.property.js']
       expect(tokens[3]).toEqual value: ' ', scopes: ['source.js']
       expect(tokens[4]).toEqual value: '=', scopes: ['source.js', 'keyword.operator.assignment.js']
@@ -1218,7 +1218,7 @@ describe "JavaScript grammar", ->
     it "tokenizes functions as object properties", ->
       {tokens} = grammar.tokenizeLine('obj.method = function foo(')
       expect(tokens[0]).toEqual value: 'obj', scopes: ['source.js', 'variable.other.object.js']
-      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.function.js', 'meta.delimiter.method.period.js']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.function.js', 'meta.delimiter.method.js']
       expect(tokens[2]).toEqual value: 'method', scopes: ['source.js', 'meta.function.js', 'entity.name.function.js']
       expect(tokens[4]).toEqual value: '=', scopes: ['source.js', 'meta.function.js', 'keyword.operator.assignment.js']
       expect(tokens[6]).toEqual value: 'function', scopes: ['source.js', 'meta.function.js', 'storage.type.function.js']
@@ -1227,12 +1227,12 @@ describe "JavaScript grammar", ->
 
       {tokens} = grammar.tokenizeLine('this.register = function(')
       expect(tokens[0]).toEqual value: 'this', scopes: ['source.js', 'variable.language.js']
-      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.function.js', 'meta.delimiter.method.period.js']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.function.js', 'meta.delimiter.method.js']
       expect(tokens[2]).toEqual value: 'register', scopes: ['source.js', 'meta.function.js', 'entity.name.function.js']
       expect(tokens[6]).toEqual value: 'function', scopes: ['source.js', 'meta.function.js', 'storage.type.function.js']
 
       {tokens} = grammar.tokenizeLine('document.getElementById("foo").onclick = function(')
-      expect(tokens[8]).toEqual value: '.', scopes: ['source.js', 'meta.function.js', 'meta.delimiter.method.period.js']
+      expect(tokens[8]).toEqual value: '.', scopes: ['source.js', 'meta.function.js', 'meta.delimiter.method.js']
       expect(tokens[9]).toEqual value: 'onclick', scopes: ['source.js', 'meta.function.js', 'entity.name.function.js']
       expect(tokens[13]).toEqual value: 'function', scopes: ['source.js', 'meta.function.js', 'storage.type.function.js']
 
@@ -1480,7 +1480,7 @@ describe "JavaScript grammar", ->
       expect(tokens[4]).toEqual value: 'thing', scopes: ['source.js', 'meta.function.js', 'meta.parameters.js', 'variable.parameter.function.js']
       expect(tokens[6]).toEqual value: '=', scopes: ['source.js', 'meta.function.js', 'meta.parameters.js', 'keyword.operator.assignment.js']
       expect(tokens[8]).toEqual value: 'this', scopes: ['source.js', 'meta.function.js', 'meta.parameters.js', 'variable.language.js']
-      expect(tokens[9]).toEqual value: '.', scopes: ['source.js', 'meta.function.js', 'meta.parameters.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+      expect(tokens[9]).toEqual value: '.', scopes: ['source.js', 'meta.function.js', 'meta.parameters.js', 'meta.method-call.js', 'meta.delimiter.method.js']
       expect(tokens[10]).toEqual value: 'something', scopes: ['source.js', 'meta.function.js', 'meta.parameters.js', 'meta.method-call.js', 'entity.name.function.js']
 
     it "tokenizes the rest parameter", ->
@@ -1626,7 +1626,7 @@ describe "JavaScript grammar", ->
 
       {tokens} = grammar.tokenizeLine('a(1.prop)')
       expect(tokens[2]).toEqual value: '1', scopes: ['source.js', 'meta.function-call.js', 'meta.arguments.js', 'invalid.illegal.identifier.js']
-      expect(tokens[3]).toEqual value: '.', scopes: ['source.js', 'meta.function-call.js', 'meta.arguments.js', 'meta.delimiter.property.period.js']
+      expect(tokens[3]).toEqual value: '.', scopes: ['source.js', 'meta.function-call.js', 'meta.arguments.js', 'meta.delimiter.property.js']
       expect(tokens[4]).toEqual value: 'prop', scopes: ['source.js', 'meta.function-call.js', 'meta.arguments.js', 'variable.other.property.js']
 
     it "tokenizes function declaration as an argument", ->
@@ -1649,7 +1649,7 @@ describe "JavaScript grammar", ->
     it "tokenizes method calls", ->
       {tokens} = grammar.tokenizeLine('a.b(1+1)')
       expect(tokens[0]).toEqual value: 'a', scopes: ['source.js', 'variable.other.object.js']
-      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.js']
       expect(tokens[2]).toEqual value: 'b', scopes: ['source.js', 'meta.method-call.js', 'entity.name.function.js']
       expect(tokens[3]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
       expect(tokens[4]).toEqual value: '1', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'constant.numeric.decimal.js']
@@ -1658,7 +1658,7 @@ describe "JavaScript grammar", ->
       expect(tokens[7]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
 
       {tokens} = grammar.tokenizeLine('a . b(1+1)')
-      expect(tokens[2]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+      expect(tokens[2]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.js']
       expect(tokens[4]).toEqual value: 'b', scopes: ['source.js', 'meta.method-call.js', 'entity.name.function.js']
       expect(tokens[5]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
 
@@ -1674,25 +1674,25 @@ describe "JavaScript grammar", ->
           .pipe(gulp.dest("build"))
       """
       expect(lines[0][0]).toEqual value: 'gulp', scopes: ['source.js', 'variable.other.object.js']
-      expect(lines[0][1]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+      expect(lines[0][1]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.js']
       expect(lines[0][2]).toEqual value: 'src', scopes: ['source.js', 'meta.method-call.js', 'entity.name.function.js']
       expect(lines[0][3]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
       expect(lines[0][4]).toEqual value: '"', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'string.quoted.double.js', 'punctuation.definition.string.begin.js']
       expect(lines[0][5]).toEqual value: './*.js', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'string.quoted.double.js']
       expect(lines[0][6]).toEqual value: '"', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'string.quoted.double.js', 'punctuation.definition.string.end.js']
       expect(lines[0][7]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
-      expect(lines[1][1]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+      expect(lines[1][1]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.js']
       expect(lines[1][2]).toEqual value: 'pipe', scopes: ['source.js', 'meta.method-call.js', 'entity.name.function.js']
       expect(lines[1][3]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
       expect(lines[1][4]).toEqual value: 'minify', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'meta.function-call.js', 'entity.name.function.js']
       expect(lines[1][5]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'meta.function-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
       expect(lines[1][6]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'meta.function-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
       expect(lines[1][7]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
-      expect(lines[2][1]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+      expect(lines[2][1]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.js']
       expect(lines[2][2]).toEqual value: 'pipe', scopes: ['source.js', 'meta.method-call.js', 'entity.name.function.js']
       expect(lines[2][3]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
       expect(lines[2][4]).toEqual value: 'gulp', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'variable.other.object.js']
-      expect(lines[2][5]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+      expect(lines[2][5]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'meta.method-call.js', 'meta.delimiter.method.js']
       expect(lines[2][6]).toEqual value: 'dest', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'meta.method-call.js', 'entity.name.function.js']
       expect(lines[2][7]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
       expect(lines[2][8]).toEqual value: '"', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'meta.method-call.js', 'meta.arguments.js', 'string.quoted.double.js', 'punctuation.definition.string.begin.js']
@@ -1708,7 +1708,7 @@ describe "JavaScript grammar", ->
       for method in methods
         it "tokenizes '#{method}'", ->
           {tokens} = grammar.tokenizeLine('.' + method + '()')
-          expect(tokens[0]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+          expect(tokens[0]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.js']
           expect(tokens[1]).toEqual value: method, scopes: ['source.js', 'meta.method-call.js', 'support.function.js']
           expect(tokens[2]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
           expect(tokens[3]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
@@ -1716,7 +1716,7 @@ describe "JavaScript grammar", ->
       for domMethod in domMethods
         it "tokenizes '#{domMethod}'", ->
           {tokens} = grammar.tokenizeLine('.' + domMethod + '()')
-          expect(tokens[0]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+          expect(tokens[0]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.js']
           expect(tokens[1]).toEqual value: domMethod, scopes: ['source.js', 'meta.method-call.js', 'support.function.dom.js']
           expect(tokens[2]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
           expect(tokens[3]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
@@ -1725,17 +1725,17 @@ describe "JavaScript grammar", ->
     it "tokenizes properties", ->
       {tokens} = grammar.tokenizeLine('obj.property')
       expect(tokens[0]).toEqual value: 'obj', scopes: ['source.js', 'variable.other.object.js']
-      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.property.period.js']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.property.js']
       expect(tokens[2]).toEqual value: 'property', scopes: ['source.js', 'variable.other.property.js']
 
       {tokens} = grammar.tokenizeLine('obj.property.property')
       expect(tokens[0]).toEqual value: 'obj', scopes: ['source.js', 'variable.other.object.js']
-      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.property.period.js']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.property.js']
       expect(tokens[2]).toEqual value: 'property', scopes: ['source.js', 'variable.other.object.property.js']
 
       {tokens} = grammar.tokenizeLine('obj.Property')
       expect(tokens[0]).toEqual value: 'obj', scopes: ['source.js', 'variable.other.object.js']
-      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.property.period.js']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.property.js']
       expect(tokens[2]).toEqual value: 'Property', scopes: ['source.js', 'variable.other.property.js']
 
       {tokens} = grammar.tokenizeLine('obj.$abc$')
@@ -1746,28 +1746,28 @@ describe "JavaScript grammar", ->
 
       {tokens} = grammar.tokenizeLine('a().b')
       expect(tokens[2]).toEqual value: ')', scopes: ['source.js', 'meta.function-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
-      expect(tokens[3]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.property.period.js']
+      expect(tokens[3]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.property.js']
       expect(tokens[4]).toEqual value: 'b', scopes: ['source.js', 'variable.other.property.js']
 
       {tokens} = grammar.tokenizeLine('a.123illegal')
       expect(tokens[0]).toEqual value: 'a', scopes: ['source.js']
-      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.property.period.js']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.property.js']
       expect(tokens[2]).toEqual value: '123illegal', scopes: ['source.js', 'invalid.illegal.identifier.js']
 
     it "tokenizes constant properties", ->
       {tokens} = grammar.tokenizeLine('obj.MY_CONSTANT')
       expect(tokens[0]).toEqual value: 'obj', scopes: ['source.js', 'variable.other.object.js']
-      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.property.period.js']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.property.js']
       expect(tokens[2]).toEqual value: 'MY_CONSTANT', scopes: ['source.js', 'constant.other.property.js']
 
       {tokens} = grammar.tokenizeLine('obj.MY_CONSTANT.prop')
       expect(tokens[0]).toEqual value: 'obj', scopes: ['source.js', 'variable.other.object.js']
-      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.property.period.js']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.property.js']
       expect(tokens[2]).toEqual value: 'MY_CONSTANT', scopes: ['source.js', 'constant.other.object.property.js']
 
       {tokens} = grammar.tokenizeLine('a.C')
       expect(tokens[0]).toEqual value: 'a', scopes: ['source.js', 'variable.other.object.js']
-      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.property.period.js']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.property.js']
       expect(tokens[2]).toEqual value: 'C', scopes: ['source.js', 'constant.other.property.js']
 
   describe "strings and functions", ->
@@ -1776,7 +1776,7 @@ describe "JavaScript grammar", ->
       expect(tokens[0]).toEqual value: "'", scopes: ['source.js', 'string.quoted.single.js', 'punctuation.definition.string.begin.js']
       expect(tokens[1]).toEqual value: "a", scopes: ['source.js', 'string.quoted.single.js']
       expect(tokens[2]).toEqual value: "'", scopes: ['source.js', 'string.quoted.single.js', 'punctuation.definition.string.end.js']
-      expect(tokens[3]).toEqual value: ".", scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+      expect(tokens[3]).toEqual value: ".", scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.js']
       expect(tokens[4]).toEqual value: "b", scopes: ['source.js', 'meta.method-call.js', 'entity.name.function.js']
       expect(tokens[5]).toEqual value: "(", scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
       expect(tokens[6]).toEqual value: "'", scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'string.quoted.single.js', 'punctuation.definition.string.begin.js']
@@ -1911,7 +1911,7 @@ describe "JavaScript grammar", ->
     it "tokenizes console support functions", ->
       {tokens} = grammar.tokenizeLine('console.log().log()')
       expect(tokens[0]).toEqual value: 'console', scopes: ['source.js', 'entity.name.type.object.console.js']
-      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.js']
       expect(tokens[2]).toEqual value: 'log', scopes: ['source.js', 'meta.method-call.js', 'support.function.console.js']
       expect(tokens[3]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
       expect(tokens[4]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
@@ -1921,7 +1921,7 @@ describe "JavaScript grammar", ->
       expect(tokens[0]).toEqual value: 'console', scopes: ['source.js', 'entity.name.type.object.console.js']
       expect(tokens[1]).toEqual value: '/*', scopes: ['source.js', 'comment.block.empty.js', 'punctuation.definition.comment.begin.js']
       expect(tokens[2]).toEqual value: '*/', scopes: ['source.js', 'comment.block.empty.js', 'punctuation.definition.comment.end.js']
-      expect(tokens[3]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+      expect(tokens[3]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.js']
       expect(tokens[4]).toEqual value: 'log', scopes: ['source.js', 'meta.method-call.js', 'support.function.console.js']
       expect(tokens[5]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
       expect(tokens[6]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
@@ -1931,7 +1931,7 @@ describe "JavaScript grammar", ->
         .log();
       '''
       expect(lines[0][0]).toEqual value: 'console', scopes: ['source.js', 'entity.name.type.object.console.js']
-      expect(lines[1][0]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+      expect(lines[1][0]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.js']
       expect(lines[1][1]).toEqual value: 'log', scopes: ['source.js', 'meta.method-call.js', 'support.function.console.js']
       expect(lines[1][2]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
       expect(lines[1][3]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
@@ -1939,7 +1939,7 @@ describe "JavaScript grammar", ->
 
       {tokens} = grammar.tokenizeLine('console . log();')
       expect(tokens[0]).toEqual value: 'console', scopes: ['source.js', 'entity.name.type.object.console.js']
-      expect(tokens[2]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+      expect(tokens[2]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.js']
       expect(tokens[4]).toEqual value: 'log', scopes: ['source.js', 'meta.method-call.js', 'support.function.console.js']
       expect(tokens[5]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
       expect(tokens[6]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
@@ -1948,7 +1948,7 @@ describe "JavaScript grammar", ->
     it "tokenizes console custom functions", ->
       {tokens} = grammar.tokenizeLine('console.foo();')
       expect(tokens[0]).toEqual value: 'console', scopes: ['source.js', 'entity.name.type.object.console.js']
-      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.js']
       expect(tokens[2]).toEqual value: 'foo', scopes: ['source.js', 'meta.method-call.js', 'entity.name.function.js']
       expect(tokens[3]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
       expect(tokens[4]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
@@ -1966,7 +1966,7 @@ describe "JavaScript grammar", ->
     it "tokenizes math support functions/properties", ->
       {tokens} = grammar.tokenizeLine('Math.random();')
       expect(tokens[0]).toEqual value: 'Math', scopes: ['source.js', 'support.class.math.js']
-      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.js']
       expect(tokens[2]).toEqual value: 'random', scopes: ['source.js', 'meta.method-call.js', 'support.function.math.js']
       expect(tokens[3]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
       expect(tokens[4]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
@@ -1977,7 +1977,7 @@ describe "JavaScript grammar", ->
         .random();
       '''
       expect(lines[0][0]).toEqual value: 'Math', scopes: ['source.js', 'support.class.math.js']
-      expect(lines[1][0]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+      expect(lines[1][0]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.js']
       expect(lines[1][1]).toEqual value: 'random', scopes: ['source.js', 'meta.method-call.js', 'support.function.math.js']
       expect(lines[1][2]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
       expect(lines[1][3]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
@@ -1985,14 +1985,14 @@ describe "JavaScript grammar", ->
 
       {tokens} = grammar.tokenizeLine('Math.PI;')
       expect(tokens[0]).toEqual value: 'Math', scopes: ['source.js', 'support.class.math.js']
-      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.property.period.js']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.delimiter.property.js']
       expect(tokens[2]).toEqual value: 'PI', scopes: ['source.js', 'support.constant.property.math.js']
       expect(tokens[3]).toEqual value: ';', scopes: ['source.js', 'punctuation.terminator.statement.js']
 
     it "tokenizes math custom functions", ->
       {tokens} = grammar.tokenizeLine('Math.PI();')
       expect(tokens[0]).toEqual value: 'Math', scopes: ['source.js', 'support.class.math.js']
-      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.js']
       expect(tokens[2]).toEqual value: 'PI', scopes: ['source.js', 'meta.method-call.js', 'entity.name.function.js']
       expect(tokens[3]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
       expect(tokens[4]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
@@ -2007,7 +2007,7 @@ describe "JavaScript grammar", ->
     it "tokenizes promise support functions", ->
       {tokens} = grammar.tokenizeLine('Promise.race();')
       expect(tokens[0]).toEqual value: 'Promise', scopes: ['source.js', 'support.class.promise.js']
-      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.js']
       expect(tokens[2]).toEqual value: 'race', scopes: ['source.js', 'meta.method-call.js', 'support.function.promise.js']
       expect(tokens[3]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
       expect(tokens[4]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
@@ -2018,7 +2018,7 @@ describe "JavaScript grammar", ->
         .resolve();
       '''
       expect(lines[0][0]).toEqual value: 'Promise', scopes: ['source.js', 'support.class.promise.js']
-      expect(lines[1][0]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+      expect(lines[1][0]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.js']
       expect(lines[1][1]).toEqual value: 'resolve', scopes: ['source.js', 'meta.method-call.js', 'support.function.promise.js']
       expect(lines[1][2]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
       expect(lines[1][3]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']
@@ -2027,7 +2027,7 @@ describe "JavaScript grammar", ->
     it "tokenizes promise custom functions", ->
       {tokens} = grammar.tokenizeLine('Promise.anExtraFunction();')
       expect(tokens[0]).toEqual value: 'Promise', scopes: ['source.js', 'support.class.promise.js']
-      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.period.js']
+      expect(tokens[1]).toEqual value: '.', scopes: ['source.js', 'meta.method-call.js', 'meta.delimiter.method.js']
       expect(tokens[2]).toEqual value: 'anExtraFunction', scopes: ['source.js', 'meta.method-call.js', 'entity.name.function.js']
       expect(tokens[3]).toEqual value: '(', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.begin.bracket.round.js']
       expect(tokens[4]).toEqual value: ')', scopes: ['source.js', 'meta.method-call.js', 'meta.arguments.js', 'punctuation.definition.arguments.end.bracket.round.js']

--- a/spec/jsdoc-spec.coffee
+++ b/spec/jsdoc-spec.coffee
@@ -372,7 +372,7 @@ describe "JSDoc grammar", ->
         expect(tokens[10]).toEqual value: 'variable', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc']
         expect(tokens[11]).toEqual value: '=', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'keyword.operator.assignment.jsdoc']
         expect(tokens[12]).toEqual value: 'default', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'source.embedded.js', 'variable.other.object.js']
-        expect(tokens[13]).toEqual value: '.', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'source.embedded.js', 'meta.delimiter.property.period.js']
+        expect(tokens[13]).toEqual value: '.', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'source.embedded.js', 'meta.delimiter.property.js']
         expect(tokens[14]).toEqual value: 'value', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'source.embedded.js', 'support.variable.property.dom.js']
         expect(tokens[15]).toEqual value: ']', scopes: ['source.js', 'comment.block.documentation.js', 'variable.other.jsdoc', 'punctuation.definition.optional-value.end.bracket.square.jsdoc']
         expect(tokens[16]).toEqual value: ' this is the description ', scopes: ['source.js', 'comment.block.documentation.js']


### PR DESCRIPTION
### Description of the Change
Adds:
```
globalThis in 'support.variable'
self and frames in 'support.variable.dom'
```

`self === window`, and `frames === window`

Also, globalThis was added to js. It's a way to reference the value of (this) in any global scope.

MDN links:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis
https://developer.mozilla.org/en-US/docs/Web/API/Window/window
https://developer.mozilla.org/en-US/docs/Web/API/Window/self
https://developer.mozilla.org/en-US/docs/Web/API/Window/frames

Currently only updates tree-sitter-javascript.cson, and not javascript.cson

### Benefits
This is only a minor update

### Possible Drawbacks
globalThis doesn't always point to a DOM object, so it's only in support.variable

In a worker context, self resolves to `WorkerGlobalScope.self` instead of `window.self`, so maybe also put that in support.variable

