### PR TITLE
Html update

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -997,7 +997,7 @@
   }
   {
     'match': '''(?x) (?<!\\$) \\b (?:
-      (document|event|navigator|performance|screen|window)
+      (document|event|navigator|performance|screen|window|self|frames|globalThis)
       |
       (AnalyserNode|ArrayBufferView|Attr|AudioBuffer|AudioBufferSourceNode|AudioContext|AudioDestinationNode|AudioListener
       |AudioNode|AudioParam|BatteryManager|BeforeUnloadEvent|BiquadFilterNode|Blob|BufferSource|ByteString|CSS|CSSConditionRule

--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -997,7 +997,7 @@
   }
   {
     'match': '''(?x) (?<!\\$) \\b (?:
-      (document|event|navigator|performance|screen|window|self|frames|globalThis)
+      (document|event|navigator|performance|screen|window|self|frames)
       |
       (AnalyserNode|ArrayBufferView|Attr|AudioBuffer|AudioBufferSourceNode|AudioContext|AudioDestinationNode|AudioListener
       |AudioNode|AudioParam|BatteryManager|BeforeUnloadEvent|BiquadFilterNode|Blob|BufferSource|ByteString|CSS|CSSConditionRule
@@ -1112,7 +1112,7 @@
         'name': 'support.variable.property.dom.js'
   }
   {
-    'match': '(?<!\\.)\\b(module|exports|__filename|__dirname|global|process)(?!\\s*:)\\b'
+    'match': '(?<!\\.)\\b(module|exports|__filename|__dirname|global|globalThis|process)(?!\\s*:)\\b'
     'name': 'support.variable.js'
   }
   {

--- a/grammars/tree-sitter-javascript.cson
+++ b/grammars/tree-sitter-javascript.cson
@@ -114,11 +114,11 @@ scopes:
 
   'identifier': [
     {
-      match: '^(global|module|exports|__filename|__dirname)$',
+      match: '^(global|globalThis|module|exports|__filename|__dirname)$',
       scopes: 'support.variable'
     },
     {
-      match: '^(window|event|document|performance|screen|navigator|console)$'
+      match: '^(window|self|frames|event|document|performance|screen|navigator|console)$'
       scopes: 'support.variable.dom'
     },
     {


### PR DESCRIPTION
### Requirements
None

### Description of the Change
See pull #681 
Adds globalThis, self, and frames

### Notes
Both files are now consistent compared to the last pull
Note that globalThis is not in support.variable.dom, but rather support.variable, as it refers to the globalThis (which doesn't have to be Window). See MDN for this one.
I find putting globalThis in the same section as "module" and "exports" pretty strange though.