### PR TITLE
Install the exact version instead of range

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,6 @@ jobs:
         with:
           channel: ${{ matrix.atom_channel }}
 
-      - name: Install Visual Studio 2015 on Windows
-        if: ${{ contains(matrix.os, 'windows') }}
-        run: |
-          choco install visualcpp-build-tools --version=14.0.25420.1 --ignore-dependencies -y --params "'/IncludeRequired'"
-          echo ::set-env name=VCTargetsPath::'C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\v140'
-
       - name: Install dependencies
         run: apm install
 

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "coffeelint": "^1.10.1"
   },
   "dependencies": {
-    "tree-sitter-javascript": "^0.19.0",
-    "tree-sitter-jsdoc": "^0.19.0",
-    "tree-sitter-regex": "^0.19.0"
+    "tree-sitter-javascript": "0.19.0",
+    "tree-sitter-jsdoc": "0.19.0",
+    "tree-sitter-regex": "0.19.0"
   }
 }


### PR DESCRIPTION
`^version` means install any version that is compatible with the range.
This means npm can even install tree-sitter-javascript version 0.15
since in semver 0.15 should be compatible with 0.19. tree-sitter seems
to have broken semver. 0.15 is not compatible with 0.19