### PR TITLE
Add AggregateError to non-tree-sitter classes

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -973,10 +973,10 @@
   }
   {
     'match': '''(?x) (?<!\\$) \\b
-      (Array|ArrayBuffer|Atomics|Boolean|DataView|Date|Error|EvalError|Float32Array|Float64Array|Function|Generator
-      |GeneratorFunction|Int16Array|Int32Array|Int8Array|InternalError|Intl|JSON|Map|Number|Object|Proxy
-      |RangeError|ReferenceError|Reflect|RegExp|Set|SharedArrayBuffer|SIMD|String|Symbol|SyntaxError|TypeError
-      |Uint16Array|Uint32Array|Uint8Array|Uint8ClampedArray|URIError|WeakMap|WeakSet)
+      (AggregateError|Array|ArrayBuffer|Atomics|Boolean|DataView|Date|Error|EvalError|Float32Array|Float64Array
+      |Function|Generator|GeneratorFunction|Int16Array|Int32Array|Int8Array|InternalError|Intl|JSON|Map|Number
+      |Object|Proxy|RangeError|ReferenceError|Reflect|RegExp|Set|SharedArrayBuffer|SIMD|String|Symbol|SyntaxError
+      |TypeError|Uint16Array|Uint32Array|Uint8Array|Uint8ClampedArray|URIError|WeakMap|WeakSet)
       \\b
     '''
     'name': 'support.class.js'


### PR DESCRIPTION
This is a copy of #698, but remade so that there's only 1 commit and so that the tests are reflected as passing.

Copied from #698:
_________________

There are *plenty* of unsupported objects: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects, this just adds one

Kinda fixes #697. But tree-sitter still doesn't support

### Description of the Change

Add AggregateError
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

There seems to be a vertical column alignment, so it kept it.
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

Slightly more updated code
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

#697
<!-- Enter any applicable Issues here -->
