### PR TITLE
support embedded hbs

### DIFF
--- a/grammars/javascript.cson
+++ b/grammars/javascript.cson
@@ -1495,6 +1495,30 @@
         ]
       }
       {
+        'begin': '(hbs|handlebars)\\s*(`)'
+        'beginCaptures':
+          '1':
+            'name': 'entity.name.function.js'
+          '2':
+            'name': 'punctuation.definition.string.begin.js'
+        'end': '`'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.string.end.js'
+        'name': 'string.quoted.template.sql.js'
+        'patterns': [
+          {
+            'include': '#string_escapes'
+          }
+          {
+            'include': '#interpolated_js'
+          }
+          {
+            'include': 'source.handlebars'
+          }
+        ]
+      }
+      {
         'begin': '`'
         'beginCaptures':
           '0':


### PR DESCRIPTION
Caveat: I'm not sure how to test this. I'm new to Atom

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Try to support embedded hbs via template literals, as is demonstrated via:
https://hljs-glimmer.nullvoxpopuli.com/?sample=jsWithHbs

(this is used everywhere in testing, too)
<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

?

### Benefits

<!-- What benefits will be realized by the code change? -->

Handlebars developers (and consequently ember developers, even though ember doesn't use handlebars), will get syntax highlighting on hbs template strings

### Possible Drawbacks
people get color?

### Applicable Issues

<!-- Enter any applicable Issues here -->
