### PR TITLE
use let instead of var to define loop variables

### DIFF
--- a/snippets/language-javascript.cson
+++ b/snippets/language-javascript.cson
@@ -28,13 +28,13 @@
     'body': 'else if (${1:true}) {\n\t$2\n}'
   'for':
     'prefix' : 'for'
-    'body' : 'for (var ${2:i} = 0; ${2:i} < ${1:array}.length; ${2:i}++) {\n\t${1:array}[${2:i}]$3\n}'
+    'body' : 'for (let ${2:i} = 0; ${2:i} < ${1:array}.length; ${2:i}++) {\n\t${1:array}[${2:i}]$3\n}'
   'for in':
     'prefix': 'forin'
-    'body': 'for (var ${1:variable} in ${2:object}) {\n\t${3:if (${2:object}.hasOwnProperty(${1:variable})) {\n\t\t$4\n\t\\}}\n}'
+    'body': 'for (let ${1:variable} in ${2:object}) {\n\t${3:if (${2:object}.hasOwnProperty(${1:variable})) {\n\t\t$4\n\t\\}}\n}'
   'for of':
     'prefix': 'forof'
-    'body': 'for (var ${1:variable} of ${2:iterable}) {\n\t$3\n}'
+    'body': 'for (let ${1:variable} of ${2:iterable}) {\n\t$3\n}'
   'forEach':
     'prefix' : 'foreach'
     'body' : 'forEach((${1:item}, ${2:i}) => {\n\t$3\n});\n'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Use "let" instead of "var" to define loop variables.

### Alternate Designs

I can't see any other approaches.

### Benefits

Defining loop variables with "var" can lead to unwanted side effects. Therefore it is recommended to use "let".

### Possible Drawbacks

There might be some developers who are not using ES6, like very old legacy versions of node.js. I believe node.js uses "let" since version 4.0.

### Applicable Issues

At some point, we will have to switch to "let". The question is: when, if not now?
